### PR TITLE
Require network to be up in RPM init script.

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -10,7 +10,7 @@
 ### BEGIN INIT INFO
 # Provides:          <%= project_name %>
 # Default-Stop:      0 1 6
-# Required-Start:    $local_fs
+# Required-Start:    $local_fs $network
 # Required-Stop:     $local_fs
 # Short-Description: <%= project_name %>'s init script
 # Description:       <%= project_name %> is a data collector


### PR DESCRIPTION
Fix error "Unable to obtain metadata parameters: project_id zone vm_id".