### PR TITLE
gRPC support fix for logging agent

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -14,7 +14,7 @@ build_iteration 1
 # creates required build directories
 dependency "preparation"
 
-override :ruby, :version => '2.1.10'
+override :ruby, :version => '2.1.8'
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '2.4.8'
 override :postgresql, :version => '9.3.5'

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,7 +25,7 @@ license_file "LEGAL"
 #   https://bugs.ruby-lang.org/issues/11869
 # - the current status of 2.3.x is that it downloads but fails to compile.
 # - verify that all ffi libs are available for your version on all platforms.
-default_version "2.1.10"
+default_version "2.1.8"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 


### PR DESCRIPTION
* b/32656946 revert default ruby version to v2.1.8
There is a bug (https://github.com/google/protobuf/commit/866d3e5327d11b6846edb1b65f73673008a43ed2) in protobuf to fix support for Ruby version like v2.1.10. And it’s released in protobuf v3.1.0. However the latest gRPC v1.0.1 we are using in the logging agent is still using protobuf v3.0.2.
In the long term, we should upgrade to a gRPC version with protobuf (>= v3.1.0). Or we can try to force the protobuf version to be >= v3.1.0 at run time (not sure if that is feasible yet).
In the short term, we would leave the Ruby default version to 2.1.8.