### PR TITLE
Bumped fluentd version to v0.14.8

### DIFF
--- a/config/software/fluentd.rb
+++ b/config/software/fluentd.rb
@@ -1,6 +1,6 @@
 name "fluentd"
-# fluentd v0.12.28
-default_version '1f261c7ce0821432767d7246a5111fbea3f29480'
+# fluentd v0.14.8
+default_version '3d1dd53f31d1fe49508f230a71a2b4c2ceb20f47'
 
 dependency "ruby"
 #dependency "bundler"


### PR DESCRIPTION
Updated version of fluentd to v0.14.8 for the google-fluentd Logging agent.