### PR TITLE
Add a custom agent version label to the Windows Stackdriver Logging Agent logs.

### DIFF
--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -29,6 +29,11 @@
   disable_retry_limit
   # Use multiple threads for processing.
   num_threads 8
+  # Custom labels to send with logs. An agent version label will be
+  # added during the agent install process.
+  labels {
+    VERSION_LABEL_PLACE_HOLDER
+  }
 </match>
 
 <source>

--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -42,6 +42,15 @@
 ; Name of the main zip file, this is bundled into the script.
 !define ZIP_FILE "${COMPRESSED_NAME}.zip"
 
+; The version of this agent.
+!define VERSION "PLACEHOLDER"
+
+; NSIS doesn't have a good versioning story.  Until we have a good story for this
+; manually set it before each release.
+!if ${VERSION} == "PLACEHOLDER"
+    !error "VERSION is not set, please set the proper version before compiling."
+!endif
+
 
 ;--------------------------------
 ; GENERAL CONFIGURATION
@@ -212,6 +221,7 @@ Section "Install"
 
     ; Trim out newlines as WordFind cannot handle them.
     ${StrTrimNewLines} $3 "$2"
+
     ; Count the number of 'POS_FILE_PLACE_HOLDER' instances.  It should only
     ; ever be 0 or 1.  We only have it in the template file once.
     ${WordFind} "$3" "POS_FILE_PLACE_HOLDER" "#" $4
@@ -219,6 +229,15 @@ Section "Install"
     ; If we hit the place holder line replace it with the proper pos_file.
     ${If} $4 == "1"
       StrCpy $2 "  pos_file '${MAIN_INSTDIR}\pos\winevtlog.pos'$\r$\n"
+    ${EndIf}
+	
+	; Count the number of 'VERSION_LABEL_PLACE_HOLDER' instances.  It should only
+    ; ever be 0 or 1.  We only have it in the template file once.
+	${WordFind} "$3" "VERSION_LABEL_PLACE_HOLDER" "#" $4
+
+    ; If we hit the place holder line replace it with the proper label.
+    ${If} $4 == "1"
+      StrCpy $2 "    $\"agent$\":$\"windows-stackdriver-logging-agent ${VERSION}$\"$\r$\n"
     ${EndIf}
 
     ; Write the line to the config file.

--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -231,9 +231,9 @@ Section "Install"
       StrCpy $2 "  pos_file '${MAIN_INSTDIR}\pos\winevtlog.pos'$\r$\n"
     ${EndIf}
 	
-	; Count the number of 'VERSION_LABEL_PLACE_HOLDER' instances.  It should only
+    ; Count the number of 'VERSION_LABEL_PLACE_HOLDER' instances.  It should only
     ; ever be 0 or 1.  We only have it in the template file once.
-	${WordFind} "$3" "VERSION_LABEL_PLACE_HOLDER" "#" $4
+    ${WordFind} "$3" "VERSION_LABEL_PLACE_HOLDER" "#" $4
 
     ; If we hit the place holder line replace it with the proper label.
     ${If} $4 == "1"


### PR DESCRIPTION
This will allow users to see which agent version they logged with and (although a little hacky) can see the version running on the machine.
