### PR TITLE
Bump json to 1.8.3 to fix warnings

### DIFF
--- a/core_gems.rb
+++ b/core_gems.rb
@@ -1,6 +1,6 @@
 dir 'core_gems'
 download "bundler", "1.10.6"
-download "json", "1.8.1"
+download "json", "1.8.3"
 download "msgpack", "0.5.11"
 download "cool.io", "1.4.4"
 download "http_parser.rb", "0.6.0"


### PR DESCRIPTION
Fixing current warnings when restarting the agent. 

I do remember there being an issue with json-1.8.0-1.8.1 but cannot find a pull request...

I've put `puts caller` in the offending files producing json warnings and got the following diff:
```
< /opt/google-fluentd/embedded/lib/ruby/gems/2.1.0/gems/json-1.8.1/lib/json/ext.rb:13:in `<module:Ext>'
< /opt/google-fluentd/embedded/lib/ruby/gems/2.1.0/gems/json-1.8.1/lib/json/ext.rb:12:in `<module:JSON>'
< /opt/google-fluentd/embedded/lib/ruby/gems/2.1.0/gems/json-1.8.1/lib/json/ext.rb:9:in `<top (required)>'
< /opt/google-fluentd/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:69:in `require'
< /opt/google-fluentd/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:69:in `require'
< /opt/google-fluentd/embedded/lib/ruby/gems/2.1.0/gems/json-1.8.1/lib/json.rb:58:in `<module:JSON>'
< /opt/google-fluentd/embedded/lib/ruby/gems/2.1.0/gems/json-1.8.1/lib/json.rb:54:in `<top (required)>'
---
> /opt/google-fluentd/embedded/lib/ruby/gems/2.1.0/gems/json-1.8.1/lib/json.rb:1:in `<top (required)>'
```
, so it seems the module gets called by json gem itself. Some require methods have changed, so maybe that was it: https://github.com/flori/json/compare/v1.8.1...v1.8.3

This should be a no-op since I see no dep differences between 1.8.3 and 1.8.1

As soon as I bump, I don't see the warnings anymore:
```
$ sudo service google-fluentd restart
google-fluentdgle-fluentd:                                 [  OK  ]
```