### PR TITLE
Add the agent version to the installer and always write to the HKLM registry

### DIFF
--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -10,6 +10,18 @@
 #>
 
 ##############################
+#  ARGUMENTS
+##############################
+
+Param([string]$version = "")
+
+if ($version -eq "")
+{
+  Write-Output "No version set. Usage: .\generate_sdl_agent_exe.ps1 -version v1-4"
+  exit
+}
+
+##############################
 #  VARIABLES - DIRECTORIES
 ##############################
 
@@ -185,4 +197,4 @@ cp $NSIS_UNZU_DLL $NSIS_UNICODE_PLUGIN_DIR
 #  STEP 8 - COMPILE THE NSIS SCRIPT.
 ##############################
 
-& $NSIS_MAKE $STACKDRIVER_NSI
+& $NSIS_MAKE /DVERSION=$version $STACKDRIVER_NSI

--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -16,7 +16,7 @@
 !define PRODUCT "Stackdriver"
 
 ; Software name used for display to users.
-!define DISPLAY_NAME "${COMPANY} ${PRODUCT} Logging Agent"
+!define DISPLAY_NAME "${COMPANY} ${PRODUCT} Logging Agent - ${VERSION}"
 
 ; Software name with no white space.
 !define COMPRESSED_NAME "${COMPANY}${PRODUCT}LoggingAgent"
@@ -54,7 +54,7 @@ Unicode true
 Name "${DISPLAY_NAME}"
 
 ; Output location/name of the installer executable.
-OutFile "${COMPRESSED_NAME}_unsigned.exe"
+OutFile "${COMPRESSED_NAME}-${VERSION}_unsigned.exe"
 
 ; Require admin level logs access, this is required as we need to read event logs.
 RequestExecutionLevel admin
@@ -113,7 +113,7 @@ Function .onInit
 
   ; Check for a previously installed version.  If one exists
   ; prompt the user to remove it before continuing.
-  ReadRegStr $0 SHCTX "${STACKDRIVER_UNINST_REG_KEY}" "UninstallString"
+  ReadRegStr $0 HKLM "${STACKDRIVER_UNINST_REG_KEY}" "UninstallString"
   ${If} $0 != ""
     ${RemoveOldVersion} "${DISPLAY_NAME}" $0
   ${EndIf}
@@ -244,7 +244,7 @@ Section "Install"
   ; Register the software so it will appear in the add/remove programs menu.
   ${Print} "Registering ${DISPLAY_NAME}..."
   ${RegisterUninstallSoftware} \
-      "${DISPLAY_NAME}" "${COMPRESSED_NAME}" "${UNINSTALLER_LOCATION}" "${UI_ICON}" "${COMPANY}" "$0"
+      "${DISPLAY_NAME}" "${COMPRESSED_NAME}" "${UNINSTALLER_LOCATION}" "${UI_ICON}" "${COMPANY}" "$0" "${VERSION}"
 
   ; Update the paths in ruby files.
   ${ExecuteCommand} "${MAIN_INSTDIR}\bin\ruby.exe" "'${MAIN_INSTDIR}\bin\gem' \
@@ -294,7 +294,7 @@ Section "Uninstall"
   ${RemoveRegisterUninstallSoftware} "${COMPRESSED_NAME}"
 
   ; Clean up any other registry entires used.
-  DeleteRegKey HKCU "${REG_KEY}"
+  DeleteRegKey HKLM "${REG_KEY}"
 
   ${UnPrint} "Cleaning up files in $INSTDIR..."
 

--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -16,7 +16,7 @@
 !define PRODUCT "Stackdriver"
 
 ; Software name used for display to users.
-!define DISPLAY_NAME "${COMPANY} ${PRODUCT} Logging Agent - ${VERSION}"
+!define DISPLAY_NAME "${COMPANY} ${PRODUCT} Logging Agent ${VERSION}"
 
 ; Software name with no white space.
 !define COMPRESSED_NAME "${COMPANY}${PRODUCT}LoggingAgent"

--- a/windows-installer/stackdriver_util.nsh
+++ b/windows-installer/stackdriver_util.nsh
@@ -189,7 +189,7 @@
 ; 
 ; Call with:
 ;   ${RegisterUninstallSoftware} "Software Name" "SoftwareName" "Uninstaller location"
-;       "Absolute path to icon" "Company name" "Estimated size in KB" "version of agent"
+;       "Absolute path to icon" "Company name" "Estimated size in KB" "Version of agent"
 ;--------------------------------
 !macro _STACKDRIVER_REGISTER_UNINSTALL_SOFTWARE_MACRO displayName compressedName uninstaller icon company sizeKB version
   ; Store global var $0 on the stack and copy the reg key to $0

--- a/windows-installer/stackdriver_util.nsh
+++ b/windows-installer/stackdriver_util.nsh
@@ -189,24 +189,25 @@
 ; 
 ; Call with:
 ;   ${RegisterUninstallSoftware} "Software Name" "SoftwareName" "Uninstaller location"
-;       "Absolute path to icon" "Company name" "Estimated size in KB"
+;       "Absolute path to icon" "Company name" "Estimated size in KB" "version of agent"
 ;--------------------------------
-!macro _STACKDRIVER_REGISTER_UNINSTALL_SOFTWARE_MACRO displayName compressedName uninstaller icon company sizeKB
+!macro _STACKDRIVER_REGISTER_UNINSTALL_SOFTWARE_MACRO displayName compressedName uninstaller icon company sizeKB version
   ; Store global var $0 on the stack and copy the reg key to $0
   Push $0
   StrCpy $0 "${UNINST_REG_KEY}\${compressedName}"
   
   ; Write all the needed register information
-  WriteRegStr SHCTX "$0" "DisplayName" "${displayName}"
-  WriteRegStr SHCTX "$0" "UninstallString" "${uninstaller}"
-  WriteRegStr SHCTX "$0" "QuietUninstallString" "${uninstaller} /S"
-  WriteRegStr SHCTX "$0" "DisplayIcon" "${icon}"
-  WriteRegStr SHCTX "$0" "Publisher" "${company}"
-  WriteRegDWORD SHCTX "$0" "EstimatedSize" "${sizeKB}"
+  WriteRegStr HKLM "$0" "DisplayName" "${displayName}"
+  WriteRegStr HKLM "$0" "UninstallString" "${uninstaller}"
+  WriteRegStr HKLM "$0" "QuietUninstallString" "${uninstaller} /S"
+  WriteRegStr HKLM "$0" "DisplayIcon" "${icon}"
+  WriteRegStr HKLM "$0" "Publisher" "${company}"
+  WriteRegDWORD HKLM "$0" "EstimatedSize" "${sizeKB}"
+  WriteRegStr HKLM "$0" "Version" "${version}"
   
   ; We do not allow modifying or reparing an install
-  WriteRegDWORD SHCTX "$0" "NoModify" 1
-  WriteRegDWORD SHCTX "$0" "NoRepair" 1
+  WriteRegDWORD HKLM "$0" "NoModify" 1
+  WriteRegDWORD HKLM "$0" "NoRepair" 1
   
   ; Restore the $0 global var
   Pop $0
@@ -228,7 +229,7 @@
 ;   ${RemoveRegisterUninstallSoftware} "SoftwareName"
 ;--------------------------------
 !macro _STACKDRIVER_REMOVE_REGISTER_UNINSTALL_SOFTWARE_MACRO name 
-  DeleteRegKey SHCTX "${UNINST_REG_KEY}\${name}"
+  DeleteRegKey HKLM "${UNINST_REG_KEY}\${name}"
 !macroend
  
  ; Define the RemoveRegisterUninstallSoftware function for ease of calling.


### PR DESCRIPTION
The agent version is now visible during the entire install and uninstall process as well as written to the registry.

Previously we wrote to SHCTX (shell context) which could write to the local machine or current user.  We should always write to the local machine as this is reading event logs which is machine wide.