### PR TITLE
Properly parse windows event log time stamps 

### DIFF
--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -13,7 +13,7 @@
     # Don't report Audits as severity as they do not convert.
     severity ${record['event_type'] && record['event_type'].length > 0 && !record['event_type']['audit'] ? record['event_type'][0].upcase : ''}
     # Parse the time the log was generated into a format 'google_cloud'
-	# can understand.
+    # can understand.
     timestampNanos ${Time.parse(record['time_generated']).tv_nsec}
     timestampSeconds ${Time.parse(record['time_generated']).tv_sec} 
   </record>

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -14,8 +14,7 @@
     severity ${record['event_type'] && record['event_type'].length > 0 && !record['event_type']['audit'] ? record['event_type'][0].upcase : ''}
     # Parse the time the log was generated into a format 'google_cloud'
     # can understand.
-    timestampNanos ${Time.parse(record['time_generated']).tv_nsec}
-    timestampSeconds ${Time.parse(record['time_generated']).tv_sec} 
+    timestamp ${t = Time.parse(record['time_generated']); {'seconds' => t.tv_sec, 'nanos' => t.tv_nsec}} 
   </record>
 </filter>
 

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -12,6 +12,10 @@
     # windows log as that matches the parsing google_cloud does.
     # Don't report Audits as severity as they do not convert.
     severity ${record['event_type'] && record['event_type'].length > 0 && !record['event_type']['audit'] ? record['event_type'][0].upcase : ''}
+    # Parse the time the log was generated into a format 'google_cloud'
+	# can understand.
+    timestampNanos ${Time.parse(record['time_generated']).tv_nsec}
+    timestampSeconds ${Time.parse(record['time_generated']).tv_sec} 
   </record>
 </filter>
 


### PR DESCRIPTION
Parse the time the log was generated into a format the google cloud logging plugin can understand.

This will ensure the log appears with the correct time.