### PR TITLE
Allow the Logging Agent Installer to install to any location

### DIFF
--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -150,8 +150,8 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 # unneeded docs that bloat the file size (and also seem to cause issues with unzipping).
 ###############################
 
-& $GEM_CMD install fluentd:0.14.14 --no-ri --no-rdoc --no-document
-& $GEM_CMD install windows-pr:1.2.5 win32-ipc:0.6.6 win32-event:0.6.3 win32-eventlog:0.6.6 win32-service:0.8.9 fluent-plugin-winevtlog:0.0.4 --no-ri --no-rdoc --no-document
+& $GEM_CMD install fluentd:0.14.13 --no-ri --no-rdoc --no-document
+& $GEM_CMD install windows-pr:1.2.5 win32-ipc:0.6.6 win32-event:0.6.3 win32-eventlog:0.6.6 win32-service:0.8.10 fluent-plugin-winevtlog:0.0.4 --no-ri --no-rdoc --no-document
 & $GEM_CMD install protobuf:3.6 google-protobuf:3.0 grpc:1.0.1 googleapis-common-protos:1.3.4 fluent-plugin-google-cloud:0.6.0 --no-ri --no-rdoc --no-document
 
 # TODO(talarico): Remove this once the bug is fixed.

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -150,7 +150,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 # unneeded docs that bloat the file size (and also seem to cause issues with unzipping).
 ###############################
 
-& $GEM_CMD install fluentd:0.14.14 --no-ri --no-rdoc --no-document
+& $GEM_CMD install fluentd:0.14.15 --no-ri --no-rdoc --no-document
 & $GEM_CMD install windows-pr:1.2.5 win32-ipc:0.6.6 win32-event:0.6.3 win32-eventlog:0.6.6 win32-service:0.8.9 fluent-plugin-winevtlog:0.0.4 --no-ri --no-rdoc --no-document
 & $GEM_CMD install protobuf:3.6 google-protobuf:3.0 grpc:1.0.1 googleapis-common-protos:1.3.4 fluent-plugin-google-cloud:0.6.0 --no-ri --no-rdoc --no-document
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -150,8 +150,8 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 # unneeded docs that bloat the file size (and also seem to cause issues with unzipping).
 ###############################
 
-& $GEM_CMD install fluentd:0.14.13 --no-ri --no-rdoc --no-document
-& $GEM_CMD install windows-pr:1.2.5 win32-ipc:0.6.6 win32-event:0.6.3 win32-eventlog:0.6.6 win32-service:0.8.10 fluent-plugin-winevtlog:0.0.4 --no-ri --no-rdoc --no-document
+& $GEM_CMD install fluentd:0.14.14 --no-ri --no-rdoc --no-document
+& $GEM_CMD install windows-pr:1.2.5 win32-ipc:0.6.6 win32-event:0.6.3 win32-eventlog:0.6.6 win32-service:0.8.9 fluent-plugin-winevtlog:0.0.4 --no-ri --no-rdoc --no-document
 & $GEM_CMD install protobuf:3.6 google-protobuf:3.0 grpc:1.0.1 googleapis-common-protos:1.3.4 fluent-plugin-google-cloud:0.6.0 --no-ri --no-rdoc --no-document
 
 # TODO(talarico): Remove this once the bug is fixed.

--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -56,6 +56,9 @@ Name "${DISPLAY_NAME}"
 ; Output location/name of the installer executable.
 OutFile "${COMPRESSED_NAME}_unsigned.exe"
 
+; Default install location.
+InstallDir "$PROGRAMFILES\Stackdriver\LoggingAgent"
+
 ; Require admin level logs access, this is required as we need to read event logs.
 RequestExecutionLevel admin
 
@@ -91,7 +94,7 @@ ${StrTrimNewLines}
 !insertmacro STACKDRIVER_SAVE_USER_LANGUAGE "${REG_KEY}"
 
 ; Configures the UI and pages for the installer. See stackdriver_ui.nsh.
-!insertmacro STACKDRIVER_UI "true"
+!insertmacro STACKDRIVER_UI "false"
 
 ; Adds all supported languages. See stackdriver_language_util.nsh.
 !insertmacro STACKDRIVER_INCLUDE_ALL_LANGUAGES
@@ -103,11 +106,6 @@ ${StrTrimNewLines}
 
 ; Function called as soon as the installer is initialized, before the GUI.
 Function .onInit
-  ; Set the install directory, we cannot do this at compile time as we are
-  ; using a runtime variable.
-  ReadEnvStr $0 SYSTEMDRIVE
-  StrCpy $INSTDIR "$0\${COMPRESSED_NAME}"
-
   ; Display the language selection dialog.
   !insertmacro MUI_LANGDLL_DISPLAY
 
@@ -120,20 +118,6 @@ Function .onInit
 
   ; Temporary directory used during install and automatically cleaned up after.
   InitPluginsDir
-FunctionEnd
-
-; Verify the install directory is correct.  There is a bug in a gem
-; that this install relies on: if the file path has a space in it, it
-; will fail to install.  For now we disable the UI to change the path
-; but also need to disable it here in case of silent installs.
-Function .onVerifyInstDir
-  ; Check that the install direcotry has not changed.  If it has, notify
-  ; the user and abort.
-  ReadEnvStr $0 SYSTEMDRIVE
-  ${If} $INSTDIR != "$0\${COMPRESSED_NAME}"
-    MessageBox MB_OK "Invalid install directory '$INSTDIR', must be '$0\${COMPRESSED_NAME}'"
-    Abort
-  ${EndIf}
 FunctionEnd
 
 


### PR DESCRIPTION
This was previously not allowed due to a bug in fluentd.  This was fixed in the most recent release and can now be allowed.