### PR TITLE
Halve the default batch size to tune API latency.

### DIFF
--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -14,8 +14,8 @@
 # Configure all sources to output to Google Cloud Logging
 <match **>
   type google_cloud
-  # Set the chunk limit conservatively to avoid exceeding the limit
-  # of 5MB per write request.
+  # Set the chunk limit conservatively to avoid exceeding the recommended
+  # chunk size of 5MB per write request.
   buffer_chunk_limit 1M
   flush_interval 5s
   # Never wait longer than 5 minutes between retries.

--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -15,8 +15,8 @@
 <match **>
   type google_cloud
   # Set the chunk limit conservatively to avoid exceeding the limit
-  # of 10MB per write request.
-  buffer_chunk_limit 2M
+  # of 5MB per write request.
+  buffer_chunk_limit 1M
   flush_interval 5s
   # Never wait longer than 5 minutes between retries.
   max_retry_wait 300

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -14,8 +14,8 @@
 # Configure all sources to output to Google Cloud Logging
 <match **>
   type google_cloud
-  # Set the chunk limit conservatively to avoid exceeding the limit
-  # of 5MB per write request.
+  # Set the chunk limit conservatively to avoid exceeding the recommended
+  # chunk size of 5MB per write request.
   buffer_chunk_limit 1M
   flush_interval 5s
   # Never wait longer than 5 minutes between retries.

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -15,8 +15,8 @@
 <match **>
   type google_cloud
   # Set the chunk limit conservatively to avoid exceeding the limit
-  # of 10MB per write request.
-  buffer_chunk_limit 2M
+  # of 5MB per write request.
+  buffer_chunk_limit 1M
   flush_interval 5s
   # Never wait longer than 5 minutes between retries.
   max_retry_wait 300


### PR DESCRIPTION
Sending smaller batches should avoid delays in batch ingestion.