### PR TITLE
Change repository for jemalloc from canonware.com to pkgs.fedoraproject.org

### DIFF
--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -1,14 +1,21 @@
 name "jemalloc"
 default_version "4.2.1"
 
-hashes = { "2.2.5" => 'a5c4332705ed0e3fff1ac73cfe975640', "3.6.0" => 'e76665b63a8fddf4c9f26d2fa67afdf2', "4.2.1" => '094b0a7b8c77c464d0dc8f0643fd3901' }
-
 # for td-agent
-hashes.each do |var, hash|
-  version("#{var}") do
-    source :md5 => hash
-    source :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{hash}/jemalloc-#{version}.tar.bz2"
-  end
+version("2.2.5") do
+  md5 = 'a5c4332705ed0e3fff1ac73cfe975640'
+  source :md5 => md5
+         :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
+end
+version("3.6.0") do
+  md5 = 'e76665b63a8fddf4c9f26d2fa67afdf2'
+  source :md5 => md5
+         :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
+end
+version("4.2.1") do
+  md5 = '094b0a7b8c77c464d0dc8f0643fd3901'
+  source :md5 => md5
+         :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
 
 # On Mac, this file blocks package building at health check so add to whitelist

--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -4,17 +4,17 @@ default_version "4.2.1"
 # for td-agent
 version("2.2.5") do
   md5 = 'a5c4332705ed0e3fff1ac73cfe975640'
-  source :md5 => md5
+  source :md5 => md5,
          :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
 version("3.6.0") do
   md5 = 'e76665b63a8fddf4c9f26d2fa67afdf2'
-  source :md5 => md5
+  source :md5 => md5,
          :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
 version("4.2.1") do
   md5 = '094b0a7b8c77c464d0dc8f0643fd3901'
-  source :md5 => md5
+  source :md5 => md5,
          :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
 

--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -1,10 +1,15 @@
 name "jemalloc"
 default_version "4.2.1"
 
+hashes = { "2.2.5" => 'a5c4332705ed0e3fff1ac73cfe975640', "3.6.0" => 'e76665b63a8fddf4c9f26d2fa67afdf2', "4.2.1" => '094b0a7b8c77c464d0dc8f0643fd3901' }
+
 # for td-agent
-version("2.2.5") { source :md5 => 'a5c4332705ed0e3fff1ac73cfe975640' }
-version("3.6.0") { source :md5 => 'e76665b63a8fddf4c9f26d2fa67afdf2' }
-version("4.2.1") { source :md5 => '094b0a7b8c77c464d0dc8f0643fd3901' }
+hashes.each do |var, hash|
+  version("#{var}") do
+    source :md5 => hash
+    source :url => "http://pkgs.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{hash}/jemalloc-#{version}.tar.bz2"
+  end
+end
 
 # On Mac, this file blocks package building at health check so add to whitelist
 whitelist_file "libjemalloc\.1\.dylib"

--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -14,7 +14,6 @@ end
 # On Mac, this file blocks package building at health check so add to whitelist
 whitelist_file "libjemalloc\.1\.dylib"
 
-source :url => "http://www.canonware.com/download/jemalloc/jemalloc-#{version}.tar.bz2"
 relative_path "jemalloc-#{version}"
 
 env = with_standard_compiler_flags(with_embedded_path)


### PR DESCRIPTION
www.canonware.com seems to be down for a while. Making the change to allow builds complete.