### PR TITLE
Add timeout to metadata server check

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -118,7 +118,7 @@ do_start() {
   if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
     return 1
   else
-    GOOGLE_LOGGING_ENABLE=$(curl --silent --connect-timeout 10 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
+    GOOGLE_LOGGING_ENABLE=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
     if [ -n "$GOOGLE_LOGGING_ENABLE" -a "$GOOGLE_LOGGING_ENABLE" = "0" ]; then
         log_warning_msg "Disabled via metadata"
         return 3

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -118,7 +118,7 @@ do_start() {
   if kill_by_file -0 "${TD_AGENT_PID_FILE}"; then
     return 1
   else
-    GOOGLE_LOGGING_ENABLE=$(curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
+    GOOGLE_LOGGING_ENABLE=$(curl --silent --connect-timeout 10 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
     if [ -n "$GOOGLE_LOGGING_ENABLE" -a "$GOOGLE_LOGGING_ENABLE" = "0" ]; then
         log_warning_msg "Disabled via metadata"
         return 3

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -195,7 +195,7 @@ do_start() {
   #   3 if daemon was not supposed to be started
   #   other if daemon could not be started or a failure occurred
 
-  GOOGLE_LOGGING_ENABLE=$(curl --silent -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
+  GOOGLE_LOGGING_ENABLE=$(curl --silent --connect-timeout 10 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
   if [ -n "$GOOGLE_LOGGING_ENABLE" -a "$GOOGLE_LOGGING_ENABLE" = "0" ]; then
       echo "Disabled via metadata"
       return 3

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -195,7 +195,7 @@ do_start() {
   #   3 if daemon was not supposed to be started
   #   other if daemon could not be started or a failure occurred
 
-  GOOGLE_LOGGING_ENABLE=$(curl --silent --connect-timeout 10 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
+  GOOGLE_LOGGING_ENABLE=$(curl --silent --connect-timeout 1 -f -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/attributes/google-logging-enable 2>/dev/null)
   if [ -n "$GOOGLE_LOGGING_ENABLE" -a "$GOOGLE_LOGGING_ENABLE" = "0" ]; then
       echo "Disabled via metadata"
       return 3


### PR DESCRIPTION
Setting a timeout allows the fluentd service to start even if the metadata service is unavailable. This would otherwise result in the process hanging.