### PR TITLE
Add a run.sh command to manage journald and systemd directories.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,4 +9,6 @@ RUN apt-get update \
     && sed -i "s/num_threads 8/num_threads 8\n  detect_json true\n  # Enable metadata agent lookups.\n  enable_metadata_agent true\n  metadata_agent_url \"http:\/\/local-metadata-agent.stackdriver.com:8000\"/" "/etc/google-fluentd/google-fluentd.conf" \
     && rm -rf /var/lib/apt/lists/*
 
-CMD /usr/sbin/google-fluentd
+ADD run.sh /run.sh
+
+CMD /run.sh

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,10 @@
+# For systems without journald
+mkdir -p /var/log/journal
+
+# Copy host libsystemd into image to avoid compatibility issues.
+if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
+  rm /lib/x86_64-linux-gnu/libsystemd*
+  cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/
+fi
+
+/usr/sbin/google-fluentd $@

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -9,4 +9,8 @@ if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
   cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/
 fi
 
+if [ ! -z "$METADATA_AGENT_HOSTNAME" ]; then
+  sed -i "s/local-metadata-agent.stackdriver.com/$METADATA_AGENT_HOSTNAME/" /etc/google-fluentd/google-fluentd.conf
+fi
+
 /usr/sbin/google-fluentd $@

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,13 +4,14 @@ mkdir -p /var/log/journal
 # Copy host libsystemd into image to avoid compatibility issues. This operation
 # is only performed if the host's lib is mounted into the container through a 
 # volume such as -v /usr/lib64/:/host/lib/.
-if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
+if [ ! -n "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
   rm /lib/x86_64-linux-gnu/libsystemd*
-  cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/
+  ln -s /host/lib/libsystemd* /lib/x86_64-linux-gnu/
 fi
 
-if [ ! -z "$METADATA_AGENT_HOSTNAME" ]; then
-  sed -i "s/local-metadata-agent.stackdriver.com/$METADATA_AGENT_HOSTNAME/" /etc/google-fluentd/google-fluentd.conf
+if [ ! -n "$METADATA_AGENT_HOSTNAME" ]; then
+  sed -i "s/local-metadata-agent.stackdriver.com/$METADATA_AGENT_HOSTNAME/" \
+    /etc/google-fluentd/google-fluentd.conf
 fi
 
 /usr/sbin/google-fluentd $@

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -14,4 +14,4 @@ if [ -n "$METADATA_AGENT_HOSTNAME" ]; then
     /etc/google-fluentd/google-fluentd.conf
 fi
 
-/usr/sbin/google-fluentd $@
+/usr/sbin/google-fluentd "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,12 +4,12 @@ mkdir -p /var/log/journal
 # Copy host libsystemd into image to avoid compatibility issues. This operation
 # is only performed if the host's lib is mounted into the container through a 
 # volume such as -v /usr/lib64/:/host/lib/.
-if [ ! -n "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
+if [ -n "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
   rm /lib/x86_64-linux-gnu/libsystemd*
   ln -s /host/lib/libsystemd* /lib/x86_64-linux-gnu/
 fi
 
-if [ ! -n "$METADATA_AGENT_HOSTNAME" ]; then
+if [ -n "$METADATA_AGENT_HOSTNAME" ]; then
   sed -i "s/local-metadata-agent.stackdriver.com/$METADATA_AGENT_HOSTNAME/" \
     /etc/google-fluentd/google-fluentd.conf
 fi

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,7 +1,9 @@
-# For systems without journald
+# For systems without journald.
 mkdir -p /var/log/journal
 
-# Copy host libsystemd into image to avoid compatibility issues.
+# Copy host libsystemd into image to avoid compatibility issues. This operation
+# is only performed if the host's lib is mounted into the container through a 
+# volume such as -v /usr/lib64/:/host/lib/.
 if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
   rm /lib/x86_64-linux-gnu/libsystemd*
   cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/


### PR DESCRIPTION
Incorporating the run.sh that can be found in fluentd-gcp's image into ours to handle journald and systemd.