### PR TITLE
Enforce retry limit by default and let users opt in forever retries if needed.

### DIFF
--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -30,15 +30,11 @@
   flush_interval 5s
   # Enforce some limit on the number of retries.
   disable_retry_limit false
-  # The maximum number of retries for sending a chunk. After this many of
-  # retries, the given chunk will be discarded.
-  retry_limit 8
-  # Wait 1 second before the first retry. The wait interval will be doubled on
-  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
-  retry_wait 1
-  # Never wait longer than 5 minutes between retries. If the wait interval
-  # reaches this limit, the exponentiation stops.
-  max_retry_wait 300
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -28,10 +28,17 @@
   buffer_chunk_limit 1M
   # Flush logs every 5 seconds, even if the buffer is not full.
   flush_interval 5s
-  # Never wait longer than 5 minutes between retries.
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # The maximum number of retries for sending a chunk. After this many of
+  # retries, the given chunk will be discarded.
+  retry_limit 8
+  # Wait 1 second before the first retry. The wait interval will be doubled on
+  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
+  retry_wait 1
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
   max_retry_wait 300
-  # Disable the limit on the number of retries (retry forever).
-  disable_retry_limit
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -34,9 +34,12 @@
   retry_limit 3
   # Wait 10 seconds before the first retry. The wait interval will be doubled on
   # each following retry (20s, 40s...) until it hits the retry limit.
-  # Note that the retry interval will be randomized to avoid burst retries.
-  # https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview#how-exponential-backoff-works
   retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops. Given the default config, this
+  # limit should never be reached. But if retry_limit and retry_wait are
+  # customized, this limit might take effect.
+  max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -34,6 +34,8 @@
   retry_limit 3
   # Wait 10 seconds before the first retry. The wait interval will be doubled on
   # each following retry (20s, 40s...) until it hits the retry limit.
+  # Note that the retry interval will be randomized to avoid burst retries.
+  # https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview#how-exponential-backoff-works
   retry_wait 10
   # Use multiple threads for processing.
   num_threads 8

--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -36,9 +36,9 @@
   # each following retry (20s, 40s...) until it hits the retry limit.
   retry_wait 10
   # Never wait longer than 5 minutes between retries. If the wait interval
-  # reaches this limit, the exponentiation stops. Given the default config, this
-  # limit should never be reached. But if retry_limit and retry_wait are
-  # customized, this limit might take effect.
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
   max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -30,15 +30,11 @@
   flush_interval 5s
   # Enforce some limit on the number of retries.
   disable_retry_limit false
-  # The maximum number of retries for sending a chunk. After this many of
-  # retries, the given chunk will be discarded.
-  retry_limit 8
-  # Wait 1 second before the first retry. The wait interval will be doubled on
-  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
-  retry_wait 1
-  # Never wait longer than 5 minutes between retries. If the wait interval
-  # reaches this limit, the exponentiation stops.
-  max_retry_wait 300
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -28,10 +28,17 @@
   buffer_chunk_limit 1M
   # Flush logs every 5 seconds, even if the buffer is not full.
   flush_interval 5s
-  # Never wait longer than 5 minutes between retries.
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # The maximum number of retries for sending a chunk. After this many of
+  # retries, the given chunk will be discarded.
+  retry_limit 8
+  # Wait 1 second before the first retry. The wait interval will be doubled on
+  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
+  retry_wait 1
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
   max_retry_wait 300
-  # Disable the limit on the number of retries (retry forever).
-  disable_retry_limit
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -34,9 +34,12 @@
   retry_limit 3
   # Wait 10 seconds before the first retry. The wait interval will be doubled on
   # each following retry (20s, 40s...) until it hits the retry limit.
-  # Note that the retry interval will be randomized to avoid burst retries.
-  # https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview#how-exponential-backoff-works
   retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops. Given the default config, this
+  # limit should never be reached. But if retry_limit and retry_wait are
+  # customized, this limit might take effect.
+  max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -34,6 +34,8 @@
   retry_limit 3
   # Wait 10 seconds before the first retry. The wait interval will be doubled on
   # each following retry (20s, 40s...) until it hits the retry limit.
+  # Note that the retry interval will be randomized to avoid burst retries.
+  # https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview#how-exponential-backoff-works
   retry_wait 10
   # Use multiple threads for processing.
   num_threads 8

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -36,9 +36,9 @@
   # each following retry (20s, 40s...) until it hits the retry limit.
   retry_wait 10
   # Never wait longer than 5 minutes between retries. If the wait interval
-  # reaches this limit, the exponentiation stops. Given the default config, this
-  # limit should never be reached. But if retry_limit and retry_wait are
-  # customized, this limit might take effect.
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
   max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -32,9 +32,12 @@
   retry_limit 3
   # Wait 10 seconds before the first retry. The wait interval will be doubled on
   # each following retry (20s, 40s...) until it hits the retry limit.
-  # Note that the retry interval will be randomized to avoid burst retries.
-  # https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview#how-exponential-backoff-works
   retry_wait 10
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops. Given the default config, this
+  # limit should never be reached. But if retry_limit and retry_wait are
+  # customized, this limit might take effect.
+  max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -26,10 +26,17 @@
   # of 10MB per write request.
   buffer_chunk_limit 1M
   flush_interval 5s
-  # Never wait longer than 5 minutes between retries.
+  # Enforce some limit on the number of retries.
+  disable_retry_limit false
+  # The maximum number of retries for sending a chunk. After this many of
+  # retries, the given chunk will be discarded.
+  retry_limit 8
+  # Wait 1 second before the first retry. The wait interval will be doubled on
+  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
+  retry_wait 1
+  # Never wait longer than 5 minutes between retries. If the wait interval
+  # reaches this limit, the exponentiation stops.
   max_retry_wait 300
-  # Disable the limit on the number of retries (retry forever).
-  disable_retry_limit
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -32,6 +32,8 @@
   retry_limit 3
   # Wait 10 seconds before the first retry. The wait interval will be doubled on
   # each following retry (20s, 40s...) until it hits the retry limit.
+  # Note that the retry interval will be randomized to avoid burst retries.
+  # https://docs.fluentd.org/v1.0/articles/buffer-plugin-overview#how-exponential-backoff-works
   retry_wait 10
   # Use multiple threads for processing.
   num_threads 8

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -34,9 +34,9 @@
   # each following retry (20s, 40s...) until it hits the retry limit.
   retry_wait 10
   # Never wait longer than 5 minutes between retries. If the wait interval
-  # reaches this limit, the exponentiation stops. Given the default config, this
-  # limit should never be reached. But if retry_limit and retry_wait are
-  # customized, this limit might take effect.
+  # reaches this limit, the exponentiation stops.
+  # Given the default config, this limit should never be reached, but if
+  # retry_limit and retry_wait are customized, this limit might take effect.
   max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -28,15 +28,11 @@
   flush_interval 5s
   # Enforce some limit on the number of retries.
   disable_retry_limit false
-  # The maximum number of retries for sending a chunk. After this many of
-  # retries, the given chunk will be discarded.
-  retry_limit 8
-  # Wait 1 second before the first retry. The wait interval will be doubled on
-  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
-  retry_wait 1
-  # Never wait longer than 5 minutes between retries. If the wait interval
-  # reaches this limit, the exponentiation stops.
-  max_retry_wait 300
+  # After 3 retries, a given chunk will be discarded.
+  retry_limit 3
+  # Wait 10 seconds before the first retry. The wait interval will be doubled on
+  # each following retry (20s, 40s...) until it hits the retry limit.
+  retry_wait 10
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.


### PR DESCRIPTION
Right now the Logging Agent by default will retry forever if any of the following errors occur:

For gRPC:
```
          # HTTP status 500 (Internal Server Error).
          GRPC::Internal,
          # HTTP status 501 (Not Implemented).
          GRPC::Unimplemented,
          # HTTP status 503 (Service Unavailable).
          GRPC::Unavailable,
          # HTTP status 504 (Gateway Timeout).
          GRPC::DeadlineExceeded
```

For REST:
```
          Google::Apis::ServerError
```

The intention is guarantee log delivery. Yet during incidents like Logging API server going down or experiencing severe latency, this "retrying forever" behavior might be an issue, consuming too much CPU and even bringing down customer's applications.

We should by default enforce some reasonable retry limit and let users opt in retrying forever if they really want to.

Sample configuration to consider (exact numbers TBD):

```
  # Enforce some limit on the number of retries.
  disable_retry_limit false
  # The maximum number of retries for sending a chunk. After this many of
  # retries, the given chunk will be discarded.
  retry_limit 8
  # Wait 1 second before the first retry. The wait interval will be doubled on
  # each following retry (2s, 4s, 8s...) until it reaches the max_retry_wait.
  retry_wait 1
  # Never wait longer than 5 minutes between retries. If the wait interval
  # reaches this limit, the exponentiation stops.
  max_retry_wait 300
```

With the configuration above, if a server is down during an outage for over (1+2+4+8+16+32+64+128) / 60 = 4.25 minutes, logs might might start to be discarded. This calculation does not include the actual time trying to write the chunk though (each retry itself might take 0.5 second, or longer if it errors after timeouts).

If we change retry_limit to be 5, then the threshold will be roughly 31 seconds. The chance of losing logs is higher, but the stability of CPU/memory usage of the Logging Agent will be better.