### PR TITLE
Change jemalloc version pin from 5.0.1 to 4.5.0.

### DIFF
--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -1,5 +1,5 @@
 name "jemalloc"
-default_version "5.0.1"
+default_version "4.5.0"
 
 # for td-agent
 version("2.2.5") do
@@ -17,8 +17,8 @@ version("4.2.1") do
   source :md5 => md5,
          :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
-version("5.0.1") do
-  sha512 = '8cb5957a5724eb2bbad120cf0028ea8b2b14b4a416c1751b7c967351a7fd51135058ea0d3c4dc1d127c86f3aa7e9fd5ef101857110aabfdb7789427791c432c3'
+version("4.5.0") do
+  sha512 = '76953363fe1007952232220afa1a91da4c1c33c02369b5ad239d8dd1d0792141197c15e8489a8f4cd301b08494e65cadd8ecd34d025cb0285700dd78d7248821'
   source :sha512 => sha512,
          :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/sha512/#{sha512}/jemalloc-#{version}.tar.bz2"
 end


### PR DESCRIPTION
b/73729943.
Our integration test caught `pthread_create` failures when installing the agent on `ubuntu-1404-trusty`. So far the issue is isolated to only `ubuntu-1404-trusty`.

Errors
```
==============================================================================
Starting installation of google-fluentd
==============================================================================

Installing agents for Debian or Ubuntu.
OK
Selecting previously unselected package google-fluentd.
(Reading database ... 42945 files and directories currently installed.)
Preparing to unpack .../google-fluentd_1.5.28-1_amd64.deb ...
Unpacking google-fluentd (1.5.28-1) ...
Selecting previously unselected package google-fluentd-catch-all-config.
Preparing to unpack .../google-fluentd-catch-all-config_0.7_all.deb ...
Unpacking google-fluentd-catch-all-config (0.7) ...
Setting up google-fluentd (1.5.28-1) ...
Adding system user `google-fluentd' (UID 107) ...
Adding new group `google-fluentd' (GID 112) ...
Adding new user `google-fluentd' (UID 107) with group `google-fluentd' ...
Not creating home directory `/home/google-fluentd'.
Installing default conffile /etc/google-fluentd/google-fluentd.conf ...
Starting google-fluentd 1.5.28: <main>: warning: pthread_create failed for timer: Invalid argument, scheduling broken
/opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/daemon.rb:142: warning: pthread_create failed for timer: Invalid argument, sc
heduling broken
/opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/daemon.rb:142: warning: pthread_create failed for timer: Invalid argument, sc
heduling broken
/opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/daemon.rb:150: warning: pthread_create failed for timer: Invalid argument, sc
heduling broken
/opt/google-fluentd/embedded/lib/ruby/gems/2.4.0/gems/serverengine-2.0.6/lib/serverengine/daemon.rb:150: warning: pthread_create failed for timer: Invalid argument, sc
heduling broken
 * google-fluentd
Setting up google-fluentd-catch-all-config (0.7) ...
Processing triggers for libc-bin (2.19-0ubuntu6.14) ...
Restarting google-fluentd: <main>: warning: pthread_create failed for timer: Invalid argument, scheduling broken
```

Seems the root cause is https://github.com/jemalloc/jemalloc/issues/1006.

I've built a package from this `lingshi-jemalloc` branch and manually tested it on a `ubuntu-1404-trusty` VM.

Broken version:
https://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-5.0.1.tar.bz2/sha512/8cb5957a5724eb2bbad120cf0028ea8b2b14b4a416c1751b7c967351a7fd51135058ea0d3c4dc1d127c86f3aa7e9fd5ef101857110aabfdb7789427791c432c3/jemalloc-5.0.1.tar.bz2

Working version:
https://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-4.5.0.tar.bz2/sha512/76953363fe1007952232220afa1a91da4c1c33c02369b5ad239d8dd1d0792141197c15e8489a8f4cd301b08494e65cadd8ecd34d025cb0285700dd78d7248821/jemalloc-4.5.0.tar.bz2