### PR TITLE
Disable split_logs_by_tag by default.

### DIFF
--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -47,6 +47,9 @@
   # If a request is a mix of valid log entries and invalid ones, ingest the
   # valid ones and drop the invalid ones instead of dropping everything.
   partial_success true
+  # Do not split log entries with different log tags into different requests
+  # when talking to Stackdriver Logging API to avoid additional latency.
+  split_logs_by_tag false
   # Enable monitoring via Prometheus integration.
   enable_monitoring true
   monitoring_type prometheus

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -47,6 +47,9 @@
   # If a request is a mix of valid log entries and invalid ones, ingest the
   # valid ones and drop the invalid ones instead of dropping everything.
   partial_success true
+  # Do not split log entries with different log tags into different requests
+  # when talking to Stackdriver Logging API to avoid additional latency.
+  split_logs_by_tag false
   # Enable monitoring via Prometheus integration.
   enable_monitoring true
   monitoring_type prometheus

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -45,6 +45,9 @@
   # If a request is a mix of valid log entries and invalid ones, ingest the
   # valid ones and drop the invalid ones instead of dropping everything.
   partial_success true
+  # Do not split log entries with different log tags into different requests
+  # when talking to Stackdriver Logging API to avoid additional latency.
+  split_logs_by_tag false
 </match>
 
 <source>


### PR DESCRIPTION
This option controls whether Stackdriver Logging Agent will split logs into separate requests based on the log tag. If true, logs with each distinct tag will be grouped into their own request. By default this is currently enabled. The original intention behind splitting logs with different tags into their own requests is to avoid repeatedly setting the log name for every log entry in the batch send to Stackdriver Logging, compressing the payload size.

While you might expect that the effect of the optimization above would be minimal, we’ve seen significant performance discrepancies when the number of distinct log tags > 30. In other words, what could all fit into one request get split into >30 requests. This substantially increases latency and consumes significantly more resource usage.
