### PR TITLE
Bump repo suffix to 20180403-1 in Dockerfile.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/* \
     && apt-get autoremove
 
-RUN curl -sS https://dl.google.com/cloudagents/install-logging-agent.sh | REPO_SUFFIX=20180322-1 DO_NOT_INSTALL_CATCH_ALL_CONFIG=true bash \
+RUN curl -sS https://dl.google.com/cloudagents/install-logging-agent.sh | REPO_SUFFIX=20180403-1 DO_NOT_INSTALL_CATCH_ALL_CONFIG=true bash \
     && rm -rf /var/lib/apt/lists/* /tmp/* \
     && apt-get autoremove \
     && find /var/log -name "*.log" -type f -delete \


### PR DESCRIPTION
Same as https://github.com/GoogleCloudPlatform/google-fluentd/pull/89, but cherry picking to the Kubernetes branch so I could build an image for K8s.