### PR TITLE
Pin systemd-journal to 1.3.0.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -24,4 +24,7 @@ download "prometheus-client", "0.4.2"
 download "fluent-plugin-multi-format-parser", "0.1.1"
 download "fluent-plugin-prometheus", "0.3.0"
 download "fluent-plugin-record-reformer", "0.9.1"
+# Pin systemd-journal to < 1.3.2 until
+# https://github.com/ledbettj/systemd-journal/issues/79 is fixed.
+download "systemd-journal", "1.3.0"
 download "fluent-plugin-systemd", "0.3.0"


### PR DESCRIPTION
Equivalent to https://github.com/GoogleCloudPlatform/google-fluentd/pull/100, but doing it the right way since we are no longer in a rush.