### PR TITLE
Don't pass start_daemon args to the agent itself -- they're not compatible.

### DIFF
--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -274,7 +274,7 @@ do_restart() {
 }
 
 do_configtest() {
-  eval "${TD_AGENT_ARGS} ${START_STOP_DAEMON_ARGS} --dry-run -q"
+  eval "${TD_AGENT_ARGS} --dry-run -q"
 }
 
 RETVAL=0


### PR DESCRIPTION
This fixes "sudo service google-fluentd restart" and "sudo service google-fluentd configtest".