### PR TITLE
Add dependencies fluent-plugin-kubernetes_metadata_filter and fluent-plugin-record-modifier.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -28,6 +28,8 @@ download "prometheus-client", "0.4.2"
 download "fluent-plugin-multi-format-parser", "0.1.1"
 download "fluent-plugin-prometheus", "0.3.0"
 download "fluent-plugin-record-reformer", "0.9.1"
+download "fluent-plugin-record-modifier", "2.0.1"
+download "fluent-plugin-kubernetes_metadata_filter", "2.1.6"
 # Pin systemd-journal to < 1.3.2 until
 # https://github.com/ledbettj/systemd-journal/issues/79 is fixed.
 download "systemd-journal", "1.3.0"


### PR DESCRIPTION
These gems are needed to populate Kubernetes metadata (e.g. pod labels) and transform the data to be something the fluent_plugin_google_cloud gem understands (e.g. "logging.googleapis.com/labels"), so that we can send the correct metadata to Stackdriver.