### PR TITLE
Roll back "Update default embedded Ruby version from 2.4 to 2.5. (#172)"

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -14,7 +14,7 @@ build_iteration 1
 # creates required build directories
 dependency "preparation"
 
-override :ruby, :version => '2.5.3'
+override :ruby, :version => '2.4.3'
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '2.4.8'
 override :postgresql, :version => '9.3.5'

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -28,7 +28,7 @@ license_file "LEGAL"
 # - Note: When updating major version (i.e. 2.2 -> 2.3), gem_dir_version must be
 #   updated to 2.X.0 in td.rb, td-agent-cleanup.rb, td-agent-files.rb, and
 #   td-agent-ui.rb.
-default_version "2.5.3"
+default_version "2.4.3"
 
 fips_enabled = (project.overrides[:fips] && project.overrides[:fips][:enabled]) || false
 
@@ -36,7 +36,7 @@ dependency "patch" if solaris_10?
 dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
 dependency "zlib"
 dependency "openssl"
-dependency "libedit" unless windows?
+dependency "libedit"
 dependency "libffi"
 dependency "libyaml"
 # Needed for chef_gem installs of (e.g.) nokogiri on upgrades -
@@ -46,20 +46,11 @@ dependency "libyaml"
 dependency "libiconv"
 
 # The checksums below are for the *.tar.gz packages.
-version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c" }
-version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
-version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
-
-version("2.4.5")      { source sha256: "6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198" }
-version("2.4.4")      { source sha256: "254f1c1a79e4cc814d1e7320bc5bdd995dc57e08727d30a767664619a9c8ae5a" }
 version("2.4.3")      { source sha256: "fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98" }
 version("2.4.2")      { source sha256: "93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c" }
 version("2.4.1")      { source sha256: "a330e10d5cb5e53b3a0078326c5731888bb55e32c4abfeb27d9e7f8e5d000250" }
 version("2.4.0")      { source sha256: "152fd0bd15a90b4a18213448f485d4b53e9f7662e1508190aa5b702446b29e3d" }
 
-version("2.3.7")      { source sha256: "35cd349cddf78e4a0640d28ec8c7e88a2ae0db51ebd8926cd232bb70db2c7d7f" }
-version("2.3.6")      { source sha256: "8322513279f9edfa612d445bc111a87894fac1128eaa539301cebfc0dd51571e" }
-version("2.3.3")      { source sha256: "241408c8c555b258846368830a06146e4849a1d58dcaf6b14a3b6a73058115b7" }
 version("2.3.1")      { source sha256: "b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd" }
 version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
 

--- a/config/software/td-agent-cleanup.rb
+++ b/config/software/td-agent-cleanup.rb
@@ -6,7 +6,7 @@ dependency "td-agent"
 build do
   block do
     project_name = project.name
-    gem_dir_version = "2.5.0"
+    gem_dir_version = "2.4.0"
 
     # remove unnecessary files
     FileUtils.rm_f(Dir.glob("/opt/#{project_name}/embedded/lib/ruby/gems/#{gem_dir_version}/cache/*.gem"))

--- a/config/software/td-agent-files.rb
+++ b/config/software/td-agent-files.rb
@@ -14,7 +14,7 @@ build do
     install_path = project.install_dir # for ERB
     project_name = project.name # for ERB
     project_name_snake = project.name.gsub('-', '_') # for variable names in ERB
-    gem_dir_version = "2.5.0"
+    gem_dir_version = "2.4.0"
 
     template = ->(*parts) { File.join('templates', *parts) }
     generate_from_template = ->(dst, src, erb_binding, opts={}) {

--- a/config/software/td-agent-ui.rb
+++ b/config/software/td-agent-ui.rb
@@ -14,7 +14,7 @@ build do
     project_name = project.name # for ERB
     project_name_snake = project.name.gsub('-', '_') # for variable names in ERB
     project_name_snake_upcase = project_name_snake.upcase
-    gem_dir_version = "2.5.0"
+    gem_dir_version = "2.4.0"
 
     template = ->(*parts) { File.join('templates', *parts) }
     generate_from_template = ->(dst, src, erb_binding, opts={}) {

--- a/config/software/td.rb
+++ b/config/software/td.rb
@@ -13,7 +13,7 @@ build do
     project_name = project.name # for ERB
     project_name_snake = project.name.gsub('-', '_') # for variable names in ERB
     project_name_snake_upcase = project_name_snake.upcase
-    gem_dir_version = "2.5.0"
+    gem_dir_version = "2.4.0"
 
     template = ->(*parts) { File.join('templates', *parts) }
     generate_from_template = ->(dst, src, erb_binding, opts={}) {


### PR DESCRIPTION
This reverts commit 352965c177630fca75e973d22486834831d4db44.

The package doesn't build with Ruby 2.5, because of
```
    /opt/google-fluentd/embedded/bin/gem install nokogiri -- --use-system-libraries --with-xml2-lib=/opt/google-fluentd/embedded/lib --with-xml2-include=/opt/google-fluentd/embedded/include/libxml2 --with-xslt-lib=/opt/google-fluentd/embedded/lib --with-xslt-include=/opt/google-fluentd/embedded/include/libxslt --with-iconv-dir=/opt/google-fluentd/embedded --with-zlib-dir=/opt/google-fluentd/embedded

    ERROR:  While executing gem ... (ArgumentError)
    wrong number of arguments (given 1, expected 0)
```