### PR TITLE
 Update base docker image to 9.9-slim for security fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ td-agent package is based on [Omnibus-ruby](https://github.com/opscode/omnibus-r
 
 ## Installation
 
-We'll assume you have Ruby 2.1 and Bundler installed. First ensure all required gems are installed and ready to use:
+We'll assume you have Ruby 2.4 and Bundler installed. First ensure all required gems are installed and ready to use:
 
 ```shell
 $ bundle install --binstubs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.6-slim
+FROM debian:9.9-slim
 
 # Default google-fluentd to the latest stable.
 # Use `docker build --build-arg REPO_SUFFIX=<CUSTOM_REPO_SUFFIX>` to override


### PR DESCRIPTION
This fixes: 
CVE-2017-15804
CVE-2017-15670
CVE-2018-11236
CVE-2017-16997
CVE-2018-15686
CVE-2017-1000408
CVE-2017-18269