### PR TITLE
Improve memory allocation strategy

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -106,7 +106,7 @@ RUN apt-get update \
     && (find /opt/google-fluentd/embedded/lib/ruby/gems/*/gems/google-api-client-*/generated/google/apis -mindepth 1 -maxdepth 1 \! -name 'logging*' | xargs rm -rf) \
     && sed -i "s/num_threads 8/num_threads 8\n  detect_json true\n  # Enable metadata agent lookups.\n  enable_metadata_agent true\n  metadata_agent_url \"http:\/\/local-metadata-agent.stackdriver.com:8000\"/" "/etc/google-fluentd/google-fluentd.conf"
 
-ENV LD_PRELOAD=/opt/google-fluentd/embedded/lib/libjemalloc.so
+ENV MALLOC_ARENA_MAX=2
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/usr/sbin/google-fluentd"]


### PR DESCRIPTION
`MALLOC_ARENA_MAX=2` reduces the number of arenas per threads. This brings the memory usage down which is a good tradeoff for a daemon deployed widely. It may slow the program down by increasing lock contention, but that seems unlikely in a low-thread application, and we haven't seen CPU increase in our load tests.

More details about this change: https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html

@igorpeshansky you were selected as a reviewer by pRNG.