### PR TITLE
Set BASE_INSTALLER_DIR to current location instead of C:

### DIFF
--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -33,7 +33,7 @@ $ErrorActionPreference = 'Stop'
 ##############################
 
 # Just install into 'C:' for simplicity.
-$BASE_INSTALLER_DIR = "C:"
+$BASE_INSTALLER_DIR = [string](Get-Location)
 
 # The path of where ruby and all gems will be.  This is the portion that will be
 # packaged and zipped up.

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -32,7 +32,7 @@ $ErrorActionPreference = 'Stop'
 #  VARIABLES - DIRECTORIES
 ##############################
 
-# Just install into 'C:' for simplicity.
+# Just install into current directory for simplicity.
 $BASE_INSTALLER_DIR = [string](Get-Location)
 
 # The path of where ruby and all gems will be.  This is the portion that will be


### PR DESCRIPTION
This fixes the following error:

```
Exception calling "CreateFromDirectory" with "2" argument(s): "Access to the
path 'C:\GoogleStackdriverLoggingAgent\rubyinstaller.exe' is denied."
At T:\src\google-fluentd\windows-installer\generate_sdl_agent_exe.ps1:180
char:1
```