### PR TITLE
Fix sles-42.3 image cannot be found error

### DIFF
--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse:42.3
+FROM opensuse:leap:42.3
 
 RUN zypper -n refresh \
  && zypper -n install \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -13,12 +13,12 @@ RUN zypper -n refresh \
         rpm-build \
         which \
         zlib-devel \
-  # RVM GPG keys
-  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
-  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
-  # RVM requires running in a login shell.
-  && /bin/bash -l -c "rvm requirements && rvm install 2.4 && gem install bundler --no-document && gem update" \
-  # Pretend we're on SLES 12
-  && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
-  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release \
-  && zypper -n clean
+  # RVM GPG keys.
+ && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ # RVM requires running in a login shell.
+ && /bin/bash -l -c "rvm requirements && rvm install 2.4 && gem install bundler --no-document && gem update" \
+ # Pretend we're on SLES 12.
+ && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
+ && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release \
+ && zypper -n clean

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse:leap:42.3
+FROM opensuse/leap:42.3
 
 RUN zypper -n refresh \
  && zypper -n install \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -20,5 +20,5 @@ RUN zypper -n refresh \
   && /bin/bash -l -c "rvm requirements && rvm install 2.4 && gem install bundler --no-document && gem update" \
   # Pretend we're on SLES 12
   && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
-  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release
-  && zypper -n clean \
+  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release \
+  && zypper -n clean

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -9,15 +9,16 @@ RUN zypper -n refresh \
         gcc-c++ \
         git \
         patch \
-        procps \
+        ruby \
         rpm-build \
         which \
         zlib-devel \
- && gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
- && zypper -n clean \
- && git config --global user.email "stackdriver-github-reader@google.com" \
- && git config --global user.name "stackdriverreader" \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
- && /bin/bash -l -c "rvm requirements && rvm install 2.4 && gem install bundler --no-ri --no-rdoc && gem update" \
- && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
- && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release
+  # RVM GPG keys
+  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+  # RVM requires running in a login shell.
+  && /bin/bash -l -c "rvm requirements && rvm install 2.4 && gem install bundler --no-document && gem update" \
+  # Pretend we're on SLES 12
+  && /bin/sed -i -e 's/VERSION = 42.3/VERSION = 12/' /etc/SuSE-release \
+  && /bin/sed -i -e 's/VERSION="42.3"/VERSION="12-SP3"/' -e 's/VERSION_ID="42.3"/VERSION_ID="12.3"/' /etc/os-release
+  && zypper -n clean \


### PR DESCRIPTION
opensuse images were removed in favor of the opensuse/leap and opensuse/tumbleweed images provided and maintained by the openSUSE Project release team.
https://build.opensuse.org/package/show/Virtualization:containers:images:openSUSE-Leap-42.3/openSUSE-Leap-42.3-container-image