### PR TITLE
Share the list of gem dependencies between Linux and Windows

### DIFF
--- a/bin/gem_installer
+++ b/bin/gem_installer
@@ -11,20 +11,14 @@ if ARGV.empty?
 end
 
 gp = GemsParser.parse(File.read(ARGV[0]))
-index = 0
-file_format = "%0#{(gp.target_files.length - 1).to_s.length}d-%s-%s.gem"
-
 FileUtils.remove_dir(gp.target_dir, true)
 Dir.mkdir(gp.target_dir)
 Dir.chdir(gp.target_dir) {
   gp.target_files.each { |n, v, an|
-    path = sprintf(file_format, index, n, v)
     loop {
-      `curl -o #{path} -L http://rubygems.org/downloads/#{n}-#{v}.gem`
-      `gem install #{path} --no-document`
+      `gem install #{n} --version #{v} --no-document`
       break if $?.success?
       sleep 1
     }
-    index += 1
   }
 }

--- a/bin/gem_installer
+++ b/bin/gem_installer
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require 'fileutils'
+$LOAD_PATH << File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib'))
+require 'gems_parser'
+
+if ARGV.empty?
+  puts "Invalid usage!"
+  puts "./bin/gem_installer gems.rb"
+  exit 0
+end
+
+gp = GemsParser.parse(File.read(ARGV[0]))
+index = 0
+file_format = "%0#{(gp.target_files.length - 1).to_s.length}d-%s-%s.gem"
+
+FileUtils.remove_dir(gp.target_dir, true)
+Dir.mkdir(gp.target_dir)
+Dir.chdir(gp.target_dir) {
+  gp.target_files.each { |n, v, an|
+    path = sprintf(file_format, index, n, v)
+    loop {
+      `curl -o #{path} -L http://rubygems.org/downloads/#{n}-#{v}.gem`
+      `gem install #{path} --no-document`
+      break if $?.success?
+      sleep 1
+    }
+    index += 1
+  }
+}

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -11,10 +11,13 @@ download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
 if windows?
   download "google-protobuf", "3.9.0"
-  download "grpc", "1.24.0"
 else
   # TODO: verify whether this works as `download` with the Linux installer, and
   # collapse the if.
   fetch "google-protobuf", "3.9.0"
+end
+unless windows?
+  # grpc currently fails to build on Windows, but it gets installed correctly
+  # when another gem pulls it in.
   fetch "grpc", "1.24.0"
 end

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -10,7 +10,7 @@ download "oj", "3.3.10"
 download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
 unless windows?
-  # Build dependencies for 'google-fluentd' that aren't needed on Windows.
+  # Gems that don't need to be fetched explicitly on Windows.
   fetch "google-protobuf", "3.7.1"
   fetch "grpc", "1.20.0"
 end

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -10,8 +10,7 @@ download "oj", "3.3.10"
 download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
 unless windows?
-  # TODO: verify whether this works as `download` with the Linux installer, and
-  # collapse the if.
+  # Build dependencies for 'google-fluentd' that aren't needed on Windows.
   fetch "google-protobuf", "3.9.0"
   fetch "grpc", "1.24.0"
 end

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -1,7 +1,7 @@
 dir 'core_gems'
 download "json", "2.1.0"
-download "msgpack", "1.2.2"
-download "cool.io", "1.5.3"
+download "msgpack", "1.2.9"
+download "cool.io", "1.5.4"
 download "http_parser.rb", "0.6.0"
 download "yajl-ruby", "1.3.1"
 download "sigdump", "0.2.4"
@@ -11,13 +11,10 @@ download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
 if windows?
   download "google-protobuf", "3.9.0"
+  download "grpc", "1.24.0"
 else
   # TODO: verify whether this works as `download` with the Linux installer, and
   # collapse the if.
   fetch "google-protobuf", "3.9.0"
-end
-unless windows?
-  # grpc currently fails to build on Windows, but it gets installed correctly
-  # when another gem pulls it in.
   fetch "grpc", "1.24.0"
 end

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -11,6 +11,6 @@ download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
 unless windows?
   # Build dependencies for 'google-fluentd' that aren't needed on Windows.
-  fetch "google-protobuf", "3.9.0"
-  fetch "grpc", "1.24.0"
+  fetch "google-protobuf", "3.7.1"
+  fetch "grpc", "1.20.0"
 end

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -9,5 +9,12 @@ download "thread_safe", "0.3.5"
 download "oj", "3.3.10"
 download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
-fetch "google-protobuf", "3.7.1"
-fetch "grpc", "1.20.0"
+if windows?
+  download "google-protobuf", "3.9.0"
+  download "grpc", "1.24.0"
+else
+  # TODO: verify whether this works as `download` with the Linux installer, and
+  # collapse the if.
+  fetch "google-protobuf", "3.9.0"
+  fetch "grpc", "1.24.0"
+end

--- a/core_gems.rb
+++ b/core_gems.rb
@@ -9,10 +9,7 @@ download "thread_safe", "0.3.5"
 download "oj", "3.3.10"
 download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
-if windows?
-  download "google-protobuf", "3.9.0"
-  download "grpc", "1.24.0"
-else
+unless windows?
   # TODO: verify whether this works as `download` with the Linux installer, and
   # collapse the if.
   fetch "google-protobuf", "3.9.0"

--- a/lib/gems_parser.rb
+++ b/lib/gems_parser.rb
@@ -24,6 +24,10 @@ class GemsParser
     @target_files << [name, ver, :download]
   end
 
+  def windows?
+    /mswin|mingw/ =~ RUBY_PLATFORM
+  end
+
   def fetch(name, ver)
     @target_files << [name, ver, :fetch]
   end

--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -27,3 +27,11 @@ download "systemd-journal", "1.3.3"
 download "fluent-plugin-systemd", "1.0.2"
 download "opencensus", "0.5.0"
 download "opencensus-stackdriver", "0.3.0"
+if windows?
+  download 'windows-pr', '1.2.6'
+  download 'win32-ipc', '0.7.0'
+  download 'win32-event', '0.6.3'
+  download 'win32-eventlog', '0.6.7'
+  download 'win32-service', '2.1.4'
+  download 'fluent-plugin-windows-eventlog', '0.2.2'
+end

--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -28,10 +28,10 @@ download "fluent-plugin-systemd", "1.0.2"
 download "opencensus", "0.5.0"
 download "opencensus-stackdriver", "0.3.0"
 if windows?
-  download 'windows-pr', '1.2.6'
-  download 'win32-ipc', '0.7.0'
-  download 'win32-event', '0.6.3'
-  download 'win32-eventlog', '0.6.7'
-  download 'win32-service', '2.1.4'
-  download 'fluent-plugin-windows-eventlog', '0.2.2'
+  download "windows-pr", "1.2.6"
+  download "win32-ipc", "0.7.0"
+  download "win32-event", "0.6.3"
+  download "win32-eventlog", "0.6.7"
+  download "win32-service", "2.1.4"
+  download "fluent-plugin-windows-eventlog", "0.2.2"
 end

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -135,18 +135,13 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 #  STEP 4 - INSTALL THE GEMS
 ##############################
 #
-# Install the needed gems for google fleuntd to works.
+# Install the needed gems for google fluentd to works.
 #
 # These are all a known set of versions which work together. Be sure things work if you
 # update any of them.
-#
-# We install all gems with '--no-document' so we don't pull in
-# unneeded docs that bloat the file size (and also seem to cause issues with unzipping).
-###############################
+x###############################
 
-& $GEM_CMD install fluentd:1.4.2 --no-document
-& $GEM_CMD install windows-pr:1.2.6 win32-ipc:0.7.0 win32-event:0.6.3 win32-eventlog:0.6.7 win32-service:2.1.4 fluent-plugin-windows-eventlog:0.2.2 --no-document
-& $GEM_CMD install google-protobuf:3.7.1 grpc:1.20.0 fluent-plugin-google-cloud:0.7.23 --no-document
+& $RUBY_EXE $PSScriptRoot\..\bin\gem_downloader plugin_gems.rb
 
 ##############################
 #  STEP 4.1 - TEMPORARY HACK TO UPDATE RUBY FILE
@@ -199,3 +194,5 @@ cp $NSIS_UNZU_DLL $NSIS_UNICODE_PLUGIN_DIR
 ##############################
 
 & $NSIS_MAKE /DVERSION=$version $STACKDRIVER_NSI
+
+Set-PSDebug -Trace 0

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -143,6 +143,9 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 #
 # These are all a known set of versions which work together. Be sure things work if you
 # update any of them.
+#
+# We install all gems with '--no-document' so we don't pull in
+# unneeded docs that bloat the file size (and also seem to cause issues with unzipping).
 ###############################
 
 $gem_installer = $SRC_ROOT + '\bin\gem_installer'

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -99,9 +99,9 @@ $STACKDRIVER_NSI = $PSScriptRoot + "\setup.nsi"
 #  STEP 1 - CREATE THE NEEDED DIRECTORIES.
 ##############################
 
-rm -r -Force $SD_LOGGING_AGENT_DIR
+rm -r -Force $SD_LOGGING_AGENT_DIR -ErrorAction Ignore
 mkdir $SD_LOGGING_AGENT_DIR
-rm -r -Force $NSIS_UNZU_DIR
+rm -r -Force $NSIS_UNZU_DIR -ErrorAction Ignore
 mkdir $NSIS_UNZU_DIR
 
 
@@ -188,7 +188,7 @@ rm -r -Force $RUBY_DEV_DIR
 ##############################
 
 Add-Type -Assembly System.IO.Compression.FileSystem
-rm -Force $STACKDRIVER_ZIP
+rm -Force $STACKDRIVER_ZIP -ErrorAction Ignore
 [System.IO.Compression.ZipFile]::CreateFromDirectory($SD_LOGGING_AGENT_DIR, $STACKDRIVER_ZIP)
 
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -72,6 +72,8 @@ $NSIS_UNZU_INSTALLER_LINK = "http://nsis.sourceforge.net/mediawiki/images/5/5a/N
 #  VARIABLES - FILE LOCATIONS
 ##############################
 
+$SRC_ROOT = $PSScriptRoot\..
+
 # The location of the ruby executable, used to set up the ruby dev kit.
 $RUBY_EXE = $SD_LOGGING_AGENT_DIR + "\bin\ruby.exe"
 
@@ -141,7 +143,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 # update any of them.
 ###############################
 
-& $RUBY_EXE $PSScriptRoot\..\bin\gem_downloader plugin_gems.rb
+& $RUBY_EXE $SRC_ROOT\bin\gem_downloader $SRC_ROOT\plugin_gems.rb
 
 ##############################
 #  STEP 4.1 - TEMPORARY HACK TO UPDATE RUBY FILE

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -186,6 +186,7 @@ rm -r -Force $RUBY_DEV_DIR
 ##############################
 
 Add-Type -Assembly System.IO.Compression.FileSystem
+rm -Force $STACKDRIVER_ZIP
 [System.IO.Compression.ZipFile]::CreateFromDirectory($SD_LOGGING_AGENT_DIR, $STACKDRIVER_ZIP)
 
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -72,7 +72,7 @@ $NSIS_UNZU_INSTALLER_LINK = "http://nsis.sourceforge.net/mediawiki/images/5/5a/N
 #  VARIABLES - FILE LOCATIONS
 ##############################
 
-$SRC_ROOT = $PSScriptRoot\..
+$SRC_ROOT = $PSScriptRoot + "\.."
 
 # The location of the ruby executable, used to set up the ruby dev kit.
 $RUBY_EXE = $SD_LOGGING_AGENT_DIR + "\bin\ruby.exe"
@@ -143,7 +143,9 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 # update any of them.
 ###############################
 
-& $RUBY_EXE $SRC_ROOT\bin\gem_downloader $SRC_ROOT\plugin_gems.rb
+$gem_downloader = $SRC_ROOT + '\bin\gem_downloader'
+$plugin_gems_rb = $SRC_ROOT + '\plugin_gems.rb'
+& $RUBY_EXE $gem_downloader $plugin_gems_rb
 
 ##############################
 #  STEP 4.1 - TEMPORARY HACK TO UPDATE RUBY FILE

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -113,18 +113,10 @@ mkdir $NSIS_UNZU_DIR
 $ProgressPreference = "silentlyContinue"
 # Handle SSL correctly.
 [Net.ServicePointManager]::SecurityProtocol = 'TLS12'
-
-# Need help with Chocolatey? See https://chocolatey.org/install
-Set-ExecutionPolicy Bypass -Scope Process -Force
-Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
-# Add Chocolatey to this session's path.
-$env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);
-
-choco install -y curl
-
-curl.exe -L "$RUBY_INSTALLER_LINK" -o "$RUBY_INSTALLER"
-curl.exe -L "$NSIS_INSTALLER_LINK" -o "$NSIS_INSTALLER"
-curl.exe -L "$NSIS_UNZU_INSTALLER_LINK" -o "$NSIS_UNZU_ZIP"
+# Pretend to be curl for Sourceforge redirects to work.
+Invoke-WebRequest "$RUBY_INSTALLER_LINK" -OutFile "$RUBY_INSTALLER" -UserAgent "curl/7.60.0"
+Invoke-WebRequest "$NSIS_INSTALLER_LINK" -OutFile "$NSIS_INSTALLER" -UserAgent "curl/7.60.0"
+Invoke-WebRequest "$NSIS_UNZU_INSTALLER_LINK" -OutFile "$NSIS_UNZU_ZIP" -UserAgent "curl/7.60.0"
 
 
 ##############################
@@ -156,6 +148,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 $gem_installer = $SRC_ROOT + '\bin\gem_installer'
 $core_gems_rb = $SRC_ROOT + '\core_gems.rb'
 $plugin_gems_rb = $SRC_ROOT + '\plugin_gems.rb'
+& $GEM_CMD install fluentd:1.4.2 --no-document
 & $RUBY_EXE $gem_installer $core_gems_rb
 & $RUBY_EXE $gem_installer $plugin_gems_rb
 
@@ -187,8 +180,8 @@ rm -r -Force $RUBY_DEV_DIR
 #  STEP 6 - ZIP THE FILES.
 ##############################
 
-Add-Type -Assembly System.IO.Compression.FileSystem
 rm -Force $STACKDRIVER_ZIP -ErrorAction Ignore
+Add-Type -Assembly System.IO.Compression.FileSystem
 [System.IO.Compression.ZipFile]::CreateFromDirectory($SD_LOGGING_AGENT_DIR, $STACKDRIVER_ZIP)
 
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -152,7 +152,9 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 ###############################
 
 $gem_installer = $SRC_ROOT + '\bin\gem_installer'
+$core_gems_rb = $SRC_ROOT + '\core_gems.rb'
 $plugin_gems_rb = $SRC_ROOT + '\plugin_gems.rb'
+& $RUBY_EXE $gem_installer $core_gems_rb
 & $RUBY_EXE $gem_installer $plugin_gems_rb
 
 ##############################

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -143,9 +143,9 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 # update any of them.
 ###############################
 
-$gem_downloader = $SRC_ROOT + '\bin\gem_downloader'
+$gem_installer = $SRC_ROOT + '\bin\gem_installer'
 $plugin_gems_rb = $SRC_ROOT + '\plugin_gems.rb'
-& $RUBY_EXE $gem_downloader $plugin_gems_rb
+& $RUBY_EXE $gem_installer $plugin_gems_rb
 
 ##############################
 #  STEP 4.1 - TEMPORARY HACK TO UPDATE RUBY FILE

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -139,7 +139,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 #
 # These are all a known set of versions which work together. Be sure things work if you
 # update any of them.
-x###############################
+###############################
 
 & $RUBY_EXE $PSScriptRoot\..\bin\gem_downloader plugin_gems.rb
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -99,8 +99,10 @@ $STACKDRIVER_NSI = $PSScriptRoot + "\setup.nsi"
 #  STEP 1 - CREATE THE NEEDED DIRECTORIES.
 ##############################
 
-New-Item -Path $SD_LOGGING_AGENT_DIR -ItemType "directory" -Force
-New-Item -Path $NSIS_UNZU_DIR -ItemType "directory" -Force
+rm -r -Force $SD_LOGGING_AGENT_DIR
+mkdir $SD_LOGGING_AGENT_DIR
+rm -r -Force $NSIS_UNZU_DIR
+mkdir $NSIS_UNZU_DIR
 
 
 ##############################

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -115,15 +115,13 @@ $ProgressPreference = "silentlyContinue"
 # Need help with Chocolatey? See https://chocolatey.org/install
 Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 # Add Chocolatey to this session's path.
-if ($($env:Path).ToLower().Contains($($chocoExePath).ToLower()) -eq $false) {
-  $env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);
-}
+$env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);
 
 choco install -y curl
 
-curl -L "$RUBY_INSTALLER_LINK" -o "$RUBY_INSTALLER"
-curl -L "$NSIS_INSTALLER_LINK" -o "$NSIS_INSTALLER"
-curl -L "$NSIS_UNZU_INSTALLER_LINK" -o "$NSIS_UNZU_ZIP"
+curl.exe -L "$RUBY_INSTALLER_LINK" -o "$RUBY_INSTALLER"
+curl.exe -L "$NSIS_INSTALLER_LINK" -o "$NSIS_INSTALLER"
+curl.exe -L "$NSIS_UNZU_INSTALLER_LINK" -o "$NSIS_UNZU_ZIP"
 
 
 ##############################

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -99,8 +99,8 @@ $STACKDRIVER_NSI = $PSScriptRoot + "\setup.nsi"
 #  STEP 1 - CREATE THE NEEDED DIRECTORIES.
 ##############################
 
-mkdir $SD_LOGGING_AGENT_DIR
-mkdir $NSIS_UNZU_DIR
+New-Item -Name $SD_LOGGING_AGENT_DIR -ItemType "directory" -Force
+New-Item -Name $NSIS_UNZU_DIR -ItemType "directory" -Force
 
 
 ##############################

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -113,7 +113,8 @@ $ProgressPreference = "silentlyContinue"
 [Net.ServicePointManager]::SecurityProtocol = 'TLS12'
 
 # Need help with Chocolatey? See https://chocolatey.org/install
-Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force
+Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 # Add Chocolatey to this session's path.
 $env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);
 
@@ -144,7 +145,7 @@ $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";"
 #  STEP 4 - INSTALL THE GEMS
 ##############################
 #
-# Install the needed gems for google fluentd to works.
+# Install the needed gems for google fluentd to work.
 #
 # These are all a known set of versions which work together. Be sure things work if you
 # update any of them.

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -111,10 +111,19 @@ mkdir $NSIS_UNZU_DIR
 $ProgressPreference = "silentlyContinue"
 # Handle SSL correctly.
 [Net.ServicePointManager]::SecurityProtocol = 'TLS12'
-# Pretend to be curl for Sourceforge redirects to work.
-Invoke-WebRequest "$RUBY_INSTALLER_LINK" -OutFile "$RUBY_INSTALLER" -UserAgent "curl/7.60.0"
-Invoke-WebRequest "$NSIS_INSTALLER_LINK" -OutFile "$NSIS_INSTALLER" -UserAgent "curl/7.60.0"
-Invoke-WebRequest "$NSIS_UNZU_INSTALLER_LINK" -OutFile "$NSIS_UNZU_ZIP" -UserAgent "curl/7.60.0"
+
+# Need help with Chocolatey? See https://chocolatey.org/install
+Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
+# Add Chocolatey to this session's path.
+if ($($env:Path).ToLower().Contains($($chocoExePath).ToLower()) -eq $false) {
+  $env:Path = [Environment]::GetEnvironmentVariable('Path',[System.EnvironmentVariableTarget]::Machine);
+}
+
+choco install -y curl
+
+curl -L "$RUBY_INSTALLER_LINK" -o "$RUBY_INSTALLER"
+curl -L "$NSIS_INSTALLER_LINK" -o "$NSIS_INSTALLER"
+curl -L "$NSIS_UNZU_INSTALLER_LINK" -o "$NSIS_UNZU_ZIP"
 
 
 ##############################

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -99,8 +99,8 @@ $STACKDRIVER_NSI = $PSScriptRoot + "\setup.nsi"
 #  STEP 1 - CREATE THE NEEDED DIRECTORIES.
 ##############################
 
-New-Item -Name $SD_LOGGING_AGENT_DIR -ItemType "directory" -Force
-New-Item -Name $NSIS_UNZU_DIR -ItemType "directory" -Force
+New-Item -Path $SD_LOGGING_AGENT_DIR -ItemType "directory" -Force
+New-Item -Path $NSIS_UNZU_DIR -ItemType "directory" -Force
 
 
 ##############################


### PR DESCRIPTION
This change bumps the version of fluentd and of some gems on the Windows side, as now we ship the same in both platforms.

I verified that the installer gives a working agent: I installed the agent and immediately saw logs in the Stackdriver UI.