### PR TITLE
Upgrade fluent-plugin-windows-eventlog gem version to 0.4.4.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -33,5 +33,5 @@ if windows?
   download "win32-event", "0.6.3"
   download "win32-eventlog", "0.6.7"
   download "win32-service", "2.1.4"
-  download "fluent-plugin-windows-eventlog", "0.2.2"
+  download "fluent-plugin-windows-eventlog", "0.4.4"
 end


### PR DESCRIPTION
This picks up https://github.com/fluent/fluent-plugin-windows-eventlog/pull/34.