### PR TITLE
Enable opencensus for core Google FluentD metrics

### DIFF
--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -57,5 +57,5 @@
   partial_success true
   # Enable monitoring via Prometheus integration.
   enable_monitoring true
-  monitoring_type prometheus
+  monitoring_type opencensus
 </match>

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -57,5 +57,5 @@
   partial_success true
   # Enable monitoring via Prometheus integration.
   enable_monitoring true
-  monitoring_type prometheus
+  monitoring_type opencensus
 </match>


### PR DESCRIPTION
This change will use OpenCensus for exporting the metrics under the `agent.googleapis.com/agent` prefix to Stackdriver. This makes monitoring work out-of-the-box, as opposed to the previous mechanism, which relied on either a Prometheus collector or the Stackdriver Monitoring agent.

I successfully tested this on a fresh installation early last week. All the backend changes are in place.

@igorpeshansky @qingling128 can you please review and confirm that these files are used by the GCE packages?