### PR TITLE
MALLOC_ARENA_MAX=2 reduces the number of arenas per threads.

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -81,7 +81,13 @@ if [ -n "${TD_AGENT_PID_FILE}" ]; then
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
-# Reduce memory usage. This gives better results than jemalloc with Ruby 2.6.
+# This brings the memory usage down which is a good tradeoff for a daemon
+# deployed widely. It may slow the program down by increasing lock contention,
+# but that seems unlikely in a low-thread application, and we haven't seen CPU
+# increase in our load tests.
+#
+# More details about this change:
+# https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html
 export MALLOC_ARENA_MAX=2
 
 kill_by_file() {

--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -81,11 +81,8 @@ if [ -n "${TD_AGENT_PID_FILE}" ]; then
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
-# 2012/04/17 Kazuki Ohta <k@treasure-data.com>
-# Use jemalloc to avoid memory fragmentation
-if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
-  export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
-fi
+# Reduce memory usage. This gives better results than jemalloc with Ruby 2.6.
+export MALLOC_ARENA_MAX=2
 
 kill_by_file() {
   local sig="$1"

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -165,11 +165,8 @@ if [ -n "${TD_AGENT_PID_FILE}" ]; then
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
-# 2012/04/17 Kazuki Ohta <k@treasure-data.com>
-# Use jemalloc to avoid memory fragmentation
-if [ -f "${TD_AGENT_HOME}/embedded/lib/libjemalloc.so" ]; then
-  export LD_PRELOAD="${TD_AGENT_HOME}/embedded/lib/libjemalloc.so"
-fi
+# Reduce memory usage. This gives better results than jemalloc with Ruby 2.6.
+export MALLOC_ARENA_MAX=2
 
 kill_by_file() {
   local sig="$1"

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -165,7 +165,13 @@ if [ -n "${TD_AGENT_PID_FILE}" ]; then
   TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
-# Reduce memory usage. This gives better results than jemalloc with Ruby 2.6.
+# This brings the memory usage down which is a good tradeoff for a daemon
+# deployed widely. It may slow the program down by increasing lock contention,
+# but that seems unlikely in a low-thread application, and we haven't seen CPU
+# increase in our load tests.
+#
+# More details about this change:
+# https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html
 export MALLOC_ARENA_MAX=2
 
 kill_by_file() {


### PR DESCRIPTION
This brings the memory usage down which is a good tradeoff for a daemon deployed widely. It may slow the program down by increasing lock contention, but that seems unlikely in a low-thread application, and we haven't seen CPU increase in our load tests.

We've been setting this in our container image for a couple months.

More details about this change: https://www.speedshop.co/2017/12/04/malloc-doubles-ruby-memory.html