### PR TITLE
Disable fluentd supervision.

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -45,7 +45,7 @@ if [ -n "${DAEMON_ARGS}" ]; then
 fi
 
 # Arguments to run the daemon with
-TD_AGENT_ARGS="${TD_AGENT_ARGS:-${TD_AGENT_BIN_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS:-${TD_AGENT_BIN_FILE} --log ${TD_AGENT_LOG_FILE} --no-supervisor ${TD_AGENT_OPTIONS}}"
 START_STOP_DAEMON_ARGS=""
 
 # Exit if the package is not installed
@@ -78,7 +78,9 @@ fi
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
-  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
+  # Work around https://github.com/fluent/fluentd/issues/2735
+  # TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --background --make-pidfile"
 fi
 
 # This brings the memory usage down which is a good tradeoff for a daemon

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -210,7 +210,15 @@ do_start() {
   fi
 
   local RETVAL=0
-  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} \& echo \$! \> "${TD_AGENT_PID_FILE}" || RETVAL="$?"
+  # daemon uses the return code of the underlying bash process as its return
+  # code. So, if you background the first command, the return code will always
+  # be that of the echo command (even if, e.g., ${TD_AGENT_RUBY} is not found
+  # or is not executable). So the only reason it would return a non-zero exit
+  # code is if it fails to write the PID file.
+  # The initial sleep 0 is needed to give the background command time to fail
+  # fast (e.g., if the executable is not available).
+  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} \
+    "${TD_AGENT_RUBY} ${TD_AGENT_ARGS} & sleep 0 && kill -0 \$! && echo \$! > ${TD_AGENT_PID_FILE} || wait \$!"
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -211,10 +211,10 @@ do_start() {
 
   local RETVAL=0
   # daemon uses the return code of the underlying bash process as its return
-  # code. So, if you background the first command, the return code will always
-  # be that of the echo command (even if, e.g., ${TD_AGENT_RUBY} is not found
-  # or is not executable). So the only reason it would return a non-zero exit
-  # code is if it fails to write the PID file.
+  # code. So, if we just background the first command, the return code will
+  # always be that of the echo command (even if, e.g., ${TD_AGENT_RUBY} is
+  # not found or is not executable). So the only reason it would return a
+  # non-zero exit code is if it fails to write the PID file.
   # The initial sleep 0 is needed to give the background command time to fail
   # fast (e.g., if the executable is not available).
   daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} \

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -210,7 +210,7 @@ do_start() {
   fi
 
   local RETVAL=0
-  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} \& echo \$! \> "${TD_AGENT_PID_FILE}"
+  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} \& echo \$! \> "${TD_AGENT_PID_FILE}" || RETVAL="$?"
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -127,7 +127,7 @@ if [ -n "${TD_AGENT_ARGS}" ]; then
 fi
 
 # Arguments to run the daemon with
-TD_AGENT_ARGS="${TD_AGENT_ARGS:-${TD_AGENT_BIN_FILE} --log ${TD_AGENT_LOG_FILE} ${TD_AGENT_OPTIONS}}"
+TD_AGENT_ARGS="${TD_AGENT_ARGS:-${TD_AGENT_BIN_FILE} --log ${TD_AGENT_LOG_FILE} --no-supervisor ${TD_AGENT_OPTIONS}}"
 START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS}"
 
 # Exit if the package is not installed
@@ -148,7 +148,9 @@ if [ -n "${TD_AGENT_USER}" ]; then
   fi
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --user ${TD_AGENT_USER}"
+  # Work around https://github.com/fluent/fluentd/issues/2735
+  # TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --background --make-pidfile"
 fi
 
 if [ -n "${TD_AGENT_GROUP}" ]; then

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -148,9 +148,7 @@ if [ -n "${TD_AGENT_USER}" ]; then
   fi
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
-  # Work around https://github.com/fluent/fluentd/issues/2735
-  # TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --background --make-pidfile"
+  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --user ${TD_AGENT_USER}"
 fi
 
 if [ -n "${TD_AGENT_GROUP}" ]; then
@@ -164,7 +162,8 @@ fi
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
-  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
+  # Work around https://github.com/fluent/fluentd/issues/2735
+  # TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
 # This brings the memory usage down which is a good tradeoff for a daemon
@@ -211,7 +210,7 @@ do_start() {
   fi
 
   local RETVAL=0
-  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} || RETVAL="$?"
+  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} \& echo \$! \> "${TD_AGENT_PID_FILE}"
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }


### PR DESCRIPTION
This saves ~60MB with the following configuration, which is similar to our default configuration. Without supervisor FluentD can only use one worker, but that is the only configuration we support. This is easy to roll back if we start supporting multiple workers in the future.

```
<match fluent.**>
  @type null
</match>
<source>
  @type systemd
  read_from_head true
  tag "systemd"
  <storage>
    @type local
    path journald-cursor.json
  </storage>
</source>
<match **>
  @type google_cloud
  buffer_chunk_limit 1M
  flush_interval 5s
  num_threads 8
  use_grpc true
</match>
```

The pidfile change is needed because of a bug in FluentD that breaks the `--daemon` features when `--no-supervisor` option is used. See https://github.com/fluent/fluentd/issues/2735.