### PR TITLE
Do not run config test when restarting.

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -184,9 +184,6 @@ do_reload() {
 }
 
 do_restart() {
-  if ! do_configtest; then
-    return 1
-  fi
   local val=0
   do_stop || val="$?"
   case "${val}" in

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -271,9 +271,6 @@ do_reload() {
 }
 
 do_restart() {
-  if ! do_configtest; then
-    return 1
-  fi
   local val=0
   do_stop || val="$?"
   case "${val}" in


### PR DESCRIPTION
When an existing service is running, config test will always fail
because the port used by prometheus plugin is occupied. Remove the
config test to avoid red herring.