### PR TITLE
Remove direct dependencies on OpenCensus gems.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -25,8 +25,6 @@ download "fluent-plugin-record-modifier", "2.0.1"
 download "fluent-plugin-kubernetes_metadata_filter", "2.4.1"
 download "systemd-journal", "1.3.3"
 download "fluent-plugin-systemd", "1.0.2"
-download "opencensus", "0.5.0"
-download "opencensus-stackdriver", "0.3.1"
 if windows?
   download "windows-pr", "1.2.6"
   download "win32-ipc", "0.7.0"


### PR DESCRIPTION
The output plugin (fluent-plugin-google-cloud) is the only thing that uses them and it handles those dependencies itself ([gemspec](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/fluent-plugin-google-cloud.gemspec)).

Reverts #216.