### PR TITLE
Upgrade fluent-plugin-kubernetes_metadata_filter gem to 2.4.5.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -22,7 +22,7 @@ download "fluent-plugin-prometheus", "1.4.0"
 download "fluent-plugin-multi-format-parser", "1.0.0"
 download "fluent-plugin-record-reformer", "0.9.1"
 download "fluent-plugin-record-modifier", "2.0.1"
-download "fluent-plugin-kubernetes_metadata_filter", "2.4.1"
+download "fluent-plugin-kubernetes_metadata_filter", "2.4.5"
 download "systemd-journal", "1.3.3"
 download "fluent-plugin-systemd", "1.0.2"
 if windows?


### PR DESCRIPTION
This is to pick up https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/214 and https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/219 fixes.