### PR TITLE
Align rvm installation commands across distros and set disable-ipv6.

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -20,6 +20,7 @@ RUN yum -y update \
  && rpm -ivh http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm \
  && yum --enablerepo=rpmforge-extras install -y git \
  # RVM GPG keys.
+ && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -15,6 +15,7 @@ RUN yum -y update \
         which \
         zlib-devel \
  # RVM GPG keys.
+ && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -15,6 +15,7 @@ RUN yum -y update \
         which \
         zlib-devel \
  # RVM GPG keys.
+ && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.

--- a/build/x86_64_debian/Dockerfile
+++ b/build/x86_64_debian/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get -y update \
         make \
         ruby \
  # RVM GPG keys.
- && gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_debian/Dockerfile
+++ b/build/x86_64_debian/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get -y update \
         make \
         ruby \
  # RVM GPG keys.
+ && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -14,6 +14,7 @@ RUN zypper -n refresh \
         which \
         zlib-devel \
  # RVM GPG keys.
+ && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -14,6 +14,7 @@ RUN zypper -n refresh \
         which \
         zlib-devel \
  # RVM GPG keys.
+ && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.


### PR DESCRIPTION
Turned out that the older distros require `--keyserver hkp://keys.gnupg.net`. Adding `--keyserver hkp://keys.gnupg.net` across the board for consistency.