### PR TITLE
Bundle fluent-plugin-concat plugin into the package to deal with Docker log split issue.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -18,6 +18,7 @@ download "fluent-plugin-detect-exceptions", "0.0.12"
 # Keep this version compatible with
 # https://github.com/fluent/fluent-plugin-prometheus/blob/master/fluent-plugin-prometheus.gemspec
 download "prometheus-client", "0.9.0"
+download "fluent-plugin-concat", "2.4.0"
 download "fluent-plugin-prometheus", "1.4.0"
 download "fluent-plugin-multi-format-parser", "1.0.0"
 download "fluent-plugin-record-reformer", "0.9.1"


### PR DESCRIPTION
Docker 1.13 changed the way how it handle logs: entries longer than 16k bytes will be split to a number of entries with size <=16k. This causes a number of problems for our customers using Stackdriver like:
- fragmented log lines
- broken jsons

This aims at bundling that plugin into our package to make it easier for customer who is impacted to concatenate the logs.