### PR TITLE
Bump minor version of google-fluentd and output plugin for next release.

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -8,7 +8,7 @@ homepage "http://cloud.google.com/logging/docs/"
 description "Google Fluentd: A data collector for Google Cloud Logging"
 
 install_dir     "/opt/google-fluentd"
-build_version   "1.6.38"
+build_version   "1.7.0"
 build_iteration 1
 
 # creates required build directories

--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -13,7 +13,7 @@ download "fluent-plugin-s3", "1.1.10"
 download "webhdfs", "0.8.0"
 download "fluent-plugin-webhdfs", "1.2.3"
 download "fluent-plugin-rewrite-tag-filter", "2.2.0"
-download "fluent-plugin-google-cloud", "0.8.7"
+download "fluent-plugin-google-cloud", "0.9.0"
 download "fluent-plugin-detect-exceptions", "0.0.12"
 # Keep this version compatible with
 # https://github.com/fluent/fluent-plugin-prometheus/blob/master/fluent-plugin-prometheus.gemspec


### PR DESCRIPTION
Pull in this [`fluent-plugin-google-cloud` version bump](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/411) that includes [new metric configuration options](https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/410) and bump minor version for `google-fluentd` because of it. 