### PR TITLE
Revert fluent-plugin-google-cloud version bump to the last released version.

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -13,7 +13,7 @@ download "fluent-plugin-s3", "1.1.10"
 download "webhdfs", "0.8.0"
 download "fluent-plugin-webhdfs", "1.2.3"
 download "fluent-plugin-rewrite-tag-filter", "2.2.0"
-download "fluent-plugin-google-cloud", "0.9.0"
+download "fluent-plugin-google-cloud", "0.8.7"
 download "fluent-plugin-detect-exceptions", "0.0.12"
 # Keep this version compatible with
 # https://github.com/fluent/fluent-plugin-prometheus/blob/master/fluent-plugin-prometheus.gemspec


### PR DESCRIPTION
Reverts part of 0123419ace5ee54de5d8e62e0be0e9fc89fdc772 (#270).