### PR TITLE
Surface curl errors when downloading gems.

### DIFF
--- a/bin/gem_downloader
+++ b/bin/gem_downloader
@@ -34,7 +34,7 @@ Dir.chdir(gp.target_dir) {
         `mv #{gem_name_version_platform}.gem #{path}`
       when :download
         # Download the native extension code and build from source.
-        `curl -o #{path} -L http://rubygems.org/downloads/#{name}-#{version}.gem`
+        `curl -f -o #{path} -L http://rubygems.org/downloads/#{name}-#{version}.gem`
       else
         fail "Unsupported gem approach: #{approach}."
       end


### PR DESCRIPTION
This improves the error message when an invalid gem version is specified.
Before this PR:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
121   243    0   243    0     0   4538      0 --:--:-- --:--:-- --:--:--  5400
ERROR:  While executing gem ... (ArgumentError)
    "ge><Requ" is not an octal string
```
After this PR:
```
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 403 Forbidden
ERROR:  Could not find a valid gem '0-fluent-plugin-google-cloud-0.9.0.gem' (>= 0) in any repository
```