### PR TITLE
Upgrade ruby to 2.6.5 on windows

### DIFF
--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -63,7 +63,7 @@ $NSIS_UNZU_ZIP = $BASE_INSTALLER_DIR + "\NSISunzU.zip"
 
 
 # Links for each installer.
-$RUBY_INSTALLER_LINK = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.5-1/rubyinstaller-devkit-2.5.5-1-x86.exe"
+$RUBY_INSTALLER_LINK = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-devkit-2.6.5-1-x86.exe"
 $NSIS_INSTALLER_LINK = "http://downloads.sourceforge.net/project/nsis/NSIS%203/3.0/nsis-3.0-setup.exe"
 $NSIS_UNZU_INSTALLER_LINK = "http://nsis.sourceforge.net/mediawiki/images/5/5a/NSISunzU.zip"
 


### PR DESCRIPTION
`grpc` version 1.30.1 is not compatible with the current 2.5.5 ruby, which couldn't load or find grpc's dynamic core (LoadError).