### PR TITLE
Update base docker image to debian:9.13-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM marketplace.gcr.io/google/debian9
+FROM debian:9.13-slim
 
 # Default google-fluentd to the latest stable.
 # Use `docker build --build-arg REPO_SUFFIX=<CUSTOM_REPO_SUFFIX>` to override

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.9-slim
+FROM marketplace.gcr.io/google/debian9
 
 # Default google-fluentd to the latest stable.
 # Use `docker build --build-arg REPO_SUFFIX=<CUSTOM_REPO_SUFFIX>` to override


### PR DESCRIPTION
The current debian 9 base image was last updated over a year ago, and vulnerabilities have been found in several packages. Using a Google managed base image that is regularly rebuilt with up to date packages allows rebuilding the image to pick up the security fixes.