### PR TITLE
Upgrade cool.io version for compatibility with Ruby 2.6.5

### DIFF
--- a/core_gems.rb
+++ b/core_gems.rb
@@ -1,7 +1,7 @@
 dir 'core_gems'
 download "json", "2.1.0"
 download "msgpack", "1.2.9"
-download "cool.io", "1.5.4"
+download "cool.io", "1.6.0"
 download "http_parser.rb", "0.6.0"
 download "yajl-ruby", "1.3.1"
 download "sigdump", "0.2.4"


### PR DESCRIPTION
Tested internally that it can build the exe. See internal bug for the result.