### PR TITLE
Set Windows agent startup type to 'Automatic (Delayed Start)'.

### DIFF
--- a/windows-installer/setup.nsi
+++ b/windows-installer/setup.nsi
@@ -212,7 +212,7 @@ Section "Install"
 
     ; Trim out newlines as WordFind cannot handle them.
     ${StrTrimNewLines} $3 "$2"
-	
+
     ; Look for 'WIN_EVT_POS_FILE_PLACE_HOLDER', if found replace it with the
     ; proper pos_file.
     ${WordFind} "$3" "WIN_EVT_POS_FILE_PLACE_HOLDER" "#" $4
@@ -262,15 +262,16 @@ Section "Install"
     pristine --all --only-executables"
 
   ; Start the fluentd service and show status.
-  ;   '--reg-winsvc i'          -> Install as a windows service
-  ;   '--reg-winsvc-auto-start' -> Enables the service to auto start at boot
-  ;   '--reg-winsvc-fluentdopt' -> Passes along the config file
-  ;   '--winsvc-name'           -> The service name the agent will run as
-  ;   '--winsvc-display-name'   -> The display name of service
-  ;   '--winsvc-desc'           -> A description of the service
+  ;   '--reg-winsvc i'           -> Install as a windows service
+  ;   '--reg-winsvc-auto-start'  -> Set service to start automatically (at boot)
+  ;   '--reg-winsvc-delay-start' -> Delay auto-start until shortly after boot
+  ;   '--reg-winsvc-fluentdopt'  -> Pass along the config file
+  ;   '--winsvc-name'            -> The service name the agent will run as
+  ;   '--winsvc-display-name'    -> The display name of service
+  ;   '--winsvc-desc'            -> A description of the service
   ${Print} "Starting the ${DISPLAY_NAME}..."
   ${ExecuteCommand} "${MAIN_INSTDIR}\bin\fluentd.bat" \
-      "--reg-winsvc i --reg-winsvc-auto-start \
+      "--reg-winsvc i --reg-winsvc-auto-start --reg-winsvc-delay-start \
       --reg-winsvc-fluentdopt $\"-c $\'${FLUENTD_CONFIG_LOCATION}$\' -o $\'${FLUENTD_LOG_LOCATION}$\'$\" \
       --winsvc-name $\"${PRODUCT}Logging$\" \
       --winsvc-display-name $\"${PRODUCT} Logging$\" \


### PR DESCRIPTION
Using flag introduced in fluent/fluentd#3037. 

Built test agent/installer off of this branch and tested it in a Windows VM. Confirmed that the startup type is updated as expected:
![image](https://user-images.githubusercontent.com/35477443/92983327-bc3f4900-f470-11ea-9c70-577b354bc431.png)
