### PR TITLE
[DO NOT MERGE] Add the analyze_config plugin to default config.

### DIFF
--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -20,6 +20,11 @@
   @type null
 </match>
 
+# Analyze the Fluentd configuration usage.
+<filter **>
+  @type analyze_config
+</filter>
+
 # Add a unique insertId to each log entry that doesn't already have it.
 # This helps guarantee the order and prevent log duplication.
 <filter **>

--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -23,6 +23,7 @@
 # Analyze the Fluentd configuration usage.
 <filter **>
   @type analyze_config
+  monitoring_type opencensus
 </filter>
 
 # Add a unique insertId to each log entry that doesn't already have it.


### PR DESCRIPTION
This enables https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/lib/fluent/plugin/filter_analyze_config.rb by default to collect Fluentd config usage data.