### PR TITLE
Bump fluent-plugin-kubernetes_metadata_filter to v2.5.2

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -23,7 +23,7 @@ download "fluent-plugin-prometheus", "1.4.0"
 download "fluent-plugin-multi-format-parser", "1.0.0"
 download "fluent-plugin-record-reformer", "0.9.1"
 download "fluent-plugin-record-modifier", "2.0.1"
-download "fluent-plugin-kubernetes_metadata_filter", "2.4.6"
+download "fluent-plugin-kubernetes_metadata_filter", "2.5.2"
 download "systemd-journal", "1.3.3"
 download "fluent-plugin-systemd", "1.0.2"
 if windows?


### PR DESCRIPTION
… to fix issues with pod and namespace watches.

Issues fixed in fluent-plugin-kubernetes_metadata_filter v2.5.2:

Add watch 410 Gone response handling by Ghazgkull · Pull Request #243 · fabric8io/fluent-plugin-kubernetes_metadata_filter
https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/243

Add 410 Gone handling for namespace watch by Ghazgkull · Pull Request #247 · fabric8io/fluent-plugin-kubernetes_metadata_filter
https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/pull/247