### PR TITLE
Create posttrans to start service

### DIFF
--- a/templates/package-scripts/td-agent/rpm/posttrans
+++ b/templates/package-scripts/td-agent/rpm/posttrans
@@ -1,0 +1,4 @@
+if [ "$1" = "0" ] ; then
+  echo "Starting <%= project_name %> ..."
+  /sbin/service <%= project_name %> start >/dev/null 2>&1 || :
+fi


### PR DESCRIPTION
This will start service when install or upgrade.

This will keep the service running even when upgrading fails google-fluentd due to then transient LoadError
(I have tested in internal bug ticket.)