### PR TITLE
Add additional dependencies that are needed to support custom windows_eventlog2 config

### DIFF
--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -31,6 +31,8 @@ if windows?
   download "win32-ipc", "0.7.0"
   download "win32-event", "0.6.3"
   download "win32-eventlog", "0.6.7"
-  download "win32-service", "2.1.4"
-  download "fluent-plugin-windows-eventlog", "0.4.4"
+  download "win32-service", "2.1.5"
+  download "fluent-plugin-windows-eventlog", "0.8.0"
+  download "nokogiri", "1.10.10"
+  download "fluent-plugin-parser-winevt_xml", "0.2.2"
 end

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -176,7 +176,7 @@ $replacement = (Get-Content $replacement_file) -join("`r`n")
 #  STEP 5 - COPY NECESSARY DLL FILES.
 ##############################
 # Save the C++ runtime DLL to allow running gems with C++ native extensions
-# included gem such as winevt_c.
+# such as winevt_c.
 $libstd_cpp_dll = $RUBY_DEV_DIR + "\mingw32\bin\libstdc++-6.dll"
 cp $libstd_cpp_dll $SD_LOGGING_AGENT_DIR\bin
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -184,8 +184,6 @@ cp $libstd_cpp_dll $SD_LOGGING_AGENT_DIR\bin
 ##############################
 #  STEP 5 - REMOVE UNNECESSARY FILES.
 ##############################
-# Save the C++ runtime DLL to allow running gems with C++ native extensions
-# included gem such as winevt_c.
 rm -r -Force $RUBY_DEV_DIR
 
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -175,7 +175,11 @@ $replacement = (Get-Content $replacement_file) -join("`r`n")
 ##############################
 #  STEP 5 - REMOVE UNNECESSARY FILES.
 ##############################
-
+# Below dll is required to put in staging_bindir to run C++ based extension
+# included gem such as winevt_c.
+$LIBSTDCPP = $RUBY_DEV_DIR + "\mingw32\bin\libstdc++-6.dll"
+$BIN = $SD_LOGGING_AGENT_DIR + "\bin"
+cp $LIBSTDCPP $BIN
 rm -r -Force $RUBY_DEV_DIR
 
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -173,7 +173,7 @@ $replacement = (Get-Content $replacement_file) -join("`r`n")
 
 
 ##############################
-#  STEP 4.2 - COPY NECESSARY DLL FILES.
+#  STEP 5 - COPY NECESSARY DLL FILES.
 ##############################
 # Save the C++ runtime DLL to allow running gems with C++ native extensions
 # included gem such as winevt_c.
@@ -182,13 +182,13 @@ cp $libstd_cpp_dll $SD_LOGGING_AGENT_DIR\bin
 
 
 ##############################
-#  STEP 5 - REMOVE UNNECESSARY FILES.
+#  STEP 6 - REMOVE UNNECESSARY FILES.
 ##############################
 rm -r -Force $RUBY_DEV_DIR
 
 
 ##############################
-#  STEP 6 - ZIP THE FILES.
+#  STEP 7 - ZIP THE FILES.
 ##############################
 
 rm -Force $STACKDRIVER_ZIP -ErrorAction Ignore
@@ -197,7 +197,7 @@ Add-Type -Assembly System.IO.Compression.FileSystem
 
 
 ##############################
-#  STEP 7 - INSTALL NSIS.
+#  STEP 8 - INSTALL NSIS.
 ##############################
 
 # Install NSIS and wait for it to finish.
@@ -211,7 +211,7 @@ cp $NSIS_UNZU_DLL $NSIS_UNICODE_PLUGIN_DIR
 
 
 ##############################
-#  STEP 8 - COMPILE THE NSIS SCRIPT.
+#  STEP 9 - COMPILE THE NSIS SCRIPT.
 ##############################
 
 & $NSIS_MAKE /DVERSION=$version $STACKDRIVER_NSI

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -173,13 +173,19 @@ $replacement = (Get-Content $replacement_file) -join("`r`n")
 
 
 ##############################
+#  STEP 4.2 - COPY NECESSARY DLL FILES.
+##############################
+# Save the C++ runtime DLL to allow running gems with C++ native extensions
+# included gem such as winevt_c.
+$libstd_cpp_dll = $RUBY_DEV_DIR + "\mingw32\bin\libstdc++-6.dll"
+cp $libstd_cpp_dll $SD_LOGGING_AGENT_DIR\bin
+
+
+##############################
 #  STEP 5 - REMOVE UNNECESSARY FILES.
 ##############################
-# Below dll is required to put in staging_bindir to run C++ based extension
+# Save the C++ runtime DLL to allow running gems with C++ native extensions
 # included gem such as winevt_c.
-$LIBSTDCPP = $RUBY_DEV_DIR + "\mingw32\bin\libstdc++-6.dll"
-$BIN = $SD_LOGGING_AGENT_DIR + "\bin"
-cp $LIBSTDCPP $BIN
 rm -r -Force $RUBY_DEV_DIR
 
 


### PR DESCRIPTION
- generate*.ps1:

This is to fix the missing dll which causes LoadError on winevt_so

See similar issues here: https://github.com/fluent-plugins-nursery/td-agent-builder/issues/98

This change is inspired by:  https://github.com/fluent-plugins-nursery/td-agent-builder/pull/103

- plugin_gems.rb:

After all the try and trials that i found during the 'joy' of experimenting built pkgs with missing deps that finally found one that works well.


Note some deps are devlopement gem for fluent-plugin-windows-eventlog: https://github.com/fluent/fluent-plugin-windows-eventlog/blob/master/fluent-plugin-winevtlog.gemspec

Note: we add support for eventlog2 but we don't support the eventlog2 configuration yet. You are on your own to deal with it. As supporting eventlog2 will be a backward incompatible change for us, the eventlog2 Log entry is very different compared to eventlog