### PR TITLE
Add supervisor mode back

### DIFF
--- a/templates/etc/init.d/deb/td-agent
+++ b/templates/etc/init.d/deb/td-agent
@@ -78,9 +78,7 @@ fi
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
-  # Work around https://github.com/fluent/fluentd/issues/2735
-  # TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
-  START_STOP_DAEMON_ARGS="${START_STOP_DAEMON_ARGS} --background --make-pidfile"
+  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
 # This brings the memory usage down which is a good tradeoff for a daemon
@@ -130,7 +128,7 @@ do_start() {
     fi
 
     start-stop-daemon --start --quiet --pidfile "${TD_AGENT_PID_FILE}" --exec "${TD_AGENT_RUBY}" \
-      ${START_STOP_DAEMON_ARGS} -- ${TD_AGENT_ARGS} --no-supervisor \
+      ${START_STOP_DAEMON_ARGS} -- ${TD_AGENT_ARGS} \
       || return 2
   fi
   # Add code here, if necessary, that waits for the process to be ready

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          <%= project_name %>
 # Required-Start:    $network $local_fs
@@ -182,8 +182,7 @@ fi
 if [ -n "${TD_AGENT_PID_FILE}" ]; then
   mkdir -p "$(dirname "${TD_AGENT_PID_FILE}")"
   chown -R "${TD_AGENT_USER}" "$(dirname "${TD_AGENT_PID_FILE}")"
-  # Work around https://github.com/fluent/fluentd/issues/2735
-  # TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
+  TD_AGENT_ARGS="${TD_AGENT_ARGS} --daemon ${TD_AGENT_PID_FILE}"
 fi
 
 # This brings the memory usage down which is a good tradeoff for a daemon
@@ -230,15 +229,7 @@ do_start() {
   fi
 
   local RETVAL=0
-  # daemon uses the return code of the underlying bash process as its return
-  # code. So, if we just background the first command, the return code will
-  # always be that of the echo command (even if, e.g., ${TD_AGENT_RUBY} is
-  # not found or is not executable). So the only reason it would return a
-  # non-zero exit code is if it fails to write the PID file.
-  # The initial sleep 0 is needed to give the background command time to fail
-  # fast (e.g., if the executable is not available).
-  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} \
-    "${TD_AGENT_RUBY} ${TD_AGENT_ARGS} --no-supervisor & sleep 0 && kill -0 \$! && echo \$! > ${TD_AGENT_PID_FILE} || wait \$!" || RETVAL="$?"
+  daemon --pidfile="${TD_AGENT_PID_FILE}" ${START_STOP_DAEMON_ARGS} "${TD_AGENT_RUBY}" ${TD_AGENT_ARGS} || RETVAL="$?"
   [ $RETVAL -eq 0 ] && touch "${TD_AGENT_LOCK_FILE}"
   return $RETVAL
 }
@@ -309,7 +300,7 @@ do_restart() {
 }
 
 do_configtest() {
-  eval "${TD_AGENT_ARGS} --dry-run -q"
+  eval "${TD_AGENT_ARGS} ${START_STOP_DAEMON_ARGS} --dry-run -q"
 }
 
 RETVAL=0

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -152,7 +152,7 @@ else
         *) return 1;;
       esac
     done
-    start_daemon "${start_daemon_args[@]}" /bin/bash -c "$@"
+    start_daemon "${start_daemon_args[@]}" "$@"
   }
 fi
 

--- a/templates/etc/init.d/rpm/td-agent
+++ b/templates/etc/init.d/rpm/td-agent
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ### BEGIN INIT INFO
 # Provides:          <%= project_name %>
 # Required-Start:    $network $local_fs
@@ -300,7 +300,7 @@ do_restart() {
 }
 
 do_configtest() {
-  eval "${TD_AGENT_ARGS} ${START_STOP_DAEMON_ARGS} --dry-run -q"
+  eval "${TD_AGENT_ARGS} --dry-run -q"
 }
 
 RETVAL=0


### PR DESCRIPTION
supervisor mode is valuable in bringing back dead workers

This reverts #225 and #230.

For centos7:
![image](https://user-images.githubusercontent.com/8354694/97492578-1c634f00-193a-11eb-97d2-0b5b9ea4fb5c.png)

For debian9:
![image](https://user-images.githubusercontent.com/8354694/97492592-21c09980-193a-11eb-8682-bf25d6315399.png)

For sles12:
![image](https://user-images.githubusercontent.com/8354694/97492610-284f1100-193a-11eb-8827-b285bc739956.png)


