### PR TITLE
Update windows fluent buffer configuration

### DIFF
--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -28,11 +28,9 @@
 
 <match **>
   @type google_cloud
-  buffer_type file
-  buffer_path /var/log/google-fluentd/buffers
   # Set the chunk limit conservatively to avoid exceeding the recommended
   # chunk size of 5MB per write request.
-  buffer_chunk_limit 512KB
+  buffer_chunk_limit 1M
   flush_interval 5s
   # Enforce some limit on the number of retries.
   disable_retry_limit false


### PR DESCRIPTION
buffer_path is a linux path on a Windows machine; removing it.
buffer_type file is not used as well, given the invalid file path; removing it.
buffer_chunk_limit of 512KB is breaking the Windows Event Log source.  Resetting this back to 1M.

For the record, the errors in the fluentd.log related to this issue are "2020-09-30 18:57:29 -0500 [info]: Worker 0 finished unexpectedly with signal SIGSEGV" and Windows logs never get sent up.  For us, this is on Windows Server 2016 machines.