### PR TITLE
Init baseline configs and add the config to analyze config usage.

### DIFF
--- a/templates/etc/td-agent/td-agent.conf
+++ b/templates/etc/td-agent/td-agent.conf
@@ -15,6 +15,12 @@
   @type prometheus_monitor
 </source>
 
+# Analyze config usage and report to Stackdriver.
+<filter **>
+  @type analyze_config
+  monitoring_type opencensus
+</filter>
+
 # Do not collect fluentd's own logs to avoid infinite loops.
 <match fluent.**>
   @type null

--- a/templates/etc/td-agent/td-agent.conf.tmpl
+++ b/templates/etc/td-agent/td-agent.conf.tmpl
@@ -15,6 +15,12 @@
   @type prometheus_monitor
 </source>
 
+# Analyze config usage and report to Stackdriver.
+<filter **>
+  @type analyze_config
+  monitoring_type opencensus
+</filter>
+
 # Do not collect fluentd's own logs to avoid infinite loops.
 <match fluent.**>
   @type null

--- a/templates/package-scripts/td-agent/deb/postinst
+++ b/templates/package-scripts/td-agent/deb/postinst
@@ -16,6 +16,7 @@ add_directories() {
     mkdir -p /var/run/<%= project_name %>
     mkdir -p /etc/<%= project_name %>
     mkdir -p /etc/<%= project_name %>/plugin
+    mkdir -p /etc/<%= project_name %>/baseline
     mkdir -p /var/log/<%= project_name %>
 }
 
@@ -70,6 +71,8 @@ case "$1" in
         add_directories
         fixperms
         update_conffile /etc/<%= project_name %>/<%= project_name %>.conf ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl
+        update_conffile /etc/<%= project_name %>/baseline/<%= project_name %>.conf ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl
+        sed -i 's/@include config\.d\/\*\.conf/@include config.d\/baseline\/*.conf/g' /etc/<%= project_name %>/baseline/<%= project_name %>.conf
         ;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :

--- a/templates/package-scripts/td-agent/rpm/post
+++ b/templates/package-scripts/td-agent/rpm/post
@@ -19,10 +19,14 @@ chown -R <%= project_name %>:<%= project_name %> /var/run/<%= project_name %>/
 if [ ! -e "/etc/<%= project_name %>/" ]; then
   mkdir -p /etc/<%= project_name %>/
   mkdir -p /etc/<%= project_name %>/plugin
+  mkdir -p /etc/<%= project_name %>/baseline
 fi
 if [ ! -e "/etc/<%= project_name %>/<%= project_name %>.conf" ]; then
   echo "Installing default conffile..."
   cp -f ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl /etc/<%= project_name %>/<%= project_name %>.conf
+  echo "Installing baseline conffile..."
+  cp -f ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl /etc/<%= project_name %>/baseline/<%= project_name %>.conf
+  sed -i 's/@include config\.d\/\*\.conf/@include config.d\/baseline\/*.conf/g' /etc/<%= project_name %>/baseline/<%= project_name %>.conf
 fi
 
 # 2011/11/13 Kazuki Ohta <k@treasure-data.com>


### PR DESCRIPTION
This goes together with https://github.com/GoogleCloudPlatform/fluentd-catch-all-config/pull/34.

The use cases we need to cover:

Case 1

Users install the google-fluentd package only. They may:
* Modify the google-fluentd.conf file (including making it include more directories / files)
* Add additional files to the conf.d folder
* Add additional files in other folders

In this case, the baseline configs should always only include the original google-fluentd.conf

Case 2

Users install both the google-fluentd package and the catch-all-config package. They may:
* Modify the google-fluentd.conf file (including making it include more directories / files)
* Modify existing files in the conf.d folder
* Add additional files to the conf.d folder
* Add additional files in other folders

In this case, the baseline configs should always only include the original google-fluentd.conf and the files we provide for the conf.d folder.