### PR TITLE
Set use_grpc to false in the default Windows config.

### DIFF
--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -49,7 +49,7 @@
   # Use multiple threads for processing.
   num_threads 8
   # Use the gRPC transport.
-  use_grpc true
+  use_grpc false
   # If a request is a mix of valid log entries and invalid ones, ingest the
   # valid ones and drop the invalid ones instead of dropping everything.
   partial_success true


### PR DESCRIPTION
This is to work around the grpc bug (b/174475386).