### PR TITLE
Pin bundler version to 2.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'open_uri_redirections', '0.2.1'
 gem 'test-kitchen',    '~> 1.2'
 gem 'kitchen-vagrant', '~> 0.14'
 
-# Pin bundler version to '2.2.3'
+# Pin bundler version to '2.2.3', the recent '2.2.4' introduces a bug when fetching the repos using `git -C clone`.
 gem 'bundler', '2.2.3'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem 'open_uri_redirections', '0.2.1'
 gem 'test-kitchen',    '~> 1.2'
 gem 'kitchen-vagrant', '~> 0.14'
 
+# Pin bundler version to '2.2.3'
+gem 'bundler', '2.2.3'
+
 group :test do
   gem 'rake', '~> 10.1.0'
   gem 'serverspec', '~> 2.18.0'


### PR DESCRIPTION
The [latest bundler 2.2.4](https://rubygems.org/gems/bundler/versions/2.2.4) causes an error below, thus pining the version back to 2.2.3

```
Fetching https://github.com/chef/omnibus.git
Unknown option: -C
usage: git [--version] [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p|--paginate|--no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           [-c name=value] [--help]
           <command> [<args>]

Retrying `git -C /main/google-fluentd clone https://github.com/chef/omnibus.git /usr/local/rvm/gems/ruby-2.5.3/cache/bundler/git/omnibus-dae08cbdfc40f037c88b5de320377a72807a8770 --bare --no-hardlinks --quiet` due to error (2/4): Bundler::Source::Git::GitCommandError Git error: command `git clone https://github.com/chef/omnibus.git /usr/local/rvm/gems/ruby-2.5.3/cache/bundler/git/omnibus-dae08cbdfc40f037c88b5de320377a72807a8770 --bare --no-hardlinks --quiet` in directory /main/google-fluentd has failed.
```