### PR TITLE
Revert "Pin bundler version to 2.2.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,6 @@ gem 'open_uri_redirections', '0.2.1'
 gem 'test-kitchen',    '~> 1.2'
 gem 'kitchen-vagrant', '~> 0.14'
 
-# Pin bundler version to '2.2.3', the recent '2.2.4' introduces a bug when fetching the repos using `git -C clone`.
-gem 'bundler', '2.2.3'
-
 group :test do
   gem 'rake', '~> 10.1.0'
   gem 'serverspec', '~> 2.18.0'


### PR DESCRIPTION
Reverts GoogleCloudPlatform/google-fluentd#310

This doesn't pin the version of bundler itself. Gemfile is used for bundle tool.