### PR TITLE
Remove the baseline sed commands to align the paths.

### DIFF
--- a/templates/package-scripts/td-agent/deb/postinst
+++ b/templates/package-scripts/td-agent/deb/postinst
@@ -72,7 +72,6 @@ case "$1" in
         fixperms
         update_conffile /etc/<%= project_name %>/<%= project_name %>.conf ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl
         update_conffile /etc/<%= project_name %>/baseline/<%= project_name %>.conf ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl
-        sed -i 's/@include config\.d\/\*\.conf/@include config.d\/baseline\/*.conf/g' /etc/<%= project_name %>/baseline/<%= project_name %>.conf
         ;;
     abort-upgrade|abort-deconfigure|abort-remove)
         :

--- a/templates/package-scripts/td-agent/rpm/post
+++ b/templates/package-scripts/td-agent/rpm/post
@@ -26,7 +26,6 @@ if [ ! -e "/etc/<%= project_name %>/<%= project_name %>.conf" ]; then
   cp -f ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl /etc/<%= project_name %>/<%= project_name %>.conf
   echo "Installing baseline conffile..."
   cp -f ${<%= project_name_snake %>_dir}/etc/<%= project_name %>/<%= project_name %>.conf.tmpl /etc/<%= project_name %>/baseline/<%= project_name %>.conf
-  sed -i 's/@include config\.d\/\*\.conf/@include config.d\/baseline\/*.conf/g' /etc/<%= project_name %>/baseline/<%= project_name %>.conf
 fi
 
 # 2011/11/13 Kazuki Ohta <k@treasure-data.com>


### PR DESCRIPTION
Fluentd `includes` can take relevant path. And we ended up putting the baseline config files under `/etc/google-fluentd/baseline/config.d/*.conf`. The sed replace is no longer needed. Tested: b/178038663