### PR TITLE
Revert "Set the default value of use_grpc back to true now that the grpc issue has been fixed. (#318)"

### DIFF
--- a/core_gems.rb
+++ b/core_gems.rb
@@ -11,6 +11,6 @@ download "tzinfo", "1.2.2"
 download "tzinfo-data", "1.2016.5"
 unless windows?
   # Gems that don't need to be fetched explicitly on Windows.
-  fetch "google-protobuf", "3.7.1"
+  fetch "google-protobuf", "3.14.0"
   fetch "grpc", "1.20.0"
 end

--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -48,7 +48,9 @@
   max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8
-  use_grpc true
+  # Use REST transport, because gRPC is expensive for structured data
+  # and has a bug (http://issuetracker.google.com/174475386).
+  use_grpc false
   # If a request is a mix of valid log entries and invalid ones, ingest the
   # valid ones and drop the invalid ones instead of dropping everything.
   partial_success true


### PR DESCRIPTION
This reverts commit 3ad481bb6344f376e11bb9bfe8ced71f26fff775, and also pin google-protobuf at 3.14.0.

The `google-protobuf` `3.15.0` version includes the segmentation fault fix, but introduced memory and cpu usage performance regression. Detailed reasons in b/181210044#comment7 and b/181210044#comment8. So we have to roll it back.

https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/453 also roll back https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/452.
