### PR TITLE
Set the default value of use_grpc back to true now that the google-protobuf issue has been fixed.

### DIFF
--- a/windows-installer/fluent-template.conf
+++ b/windows-installer/fluent-template.conf
@@ -48,9 +48,7 @@
   max_retry_wait 300
   # Use multiple threads for processing.
   num_threads 8
-  # Use REST transport, because gRPC is expensive for structured data
-  # and has a bug (http://issuetracker.google.com/174475386).
-  use_grpc false
+  use_grpc true
   # If a request is a mix of valid log entries and invalid ones, ingest the
   # valid ones and drop the invalid ones instead of dropping everything.
   partial_success true


### PR DESCRIPTION
Related underlying protobuf issue: https://github.com/protocolbuffers/protobuf/pull/8461.

More context: b/182381016#comment9