### PR TITLE
Update container from debian 9 -> debian 10

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9.13-slim
+FROM debian:10.9-slim
 
 # Default google-fluentd to the latest stable.
 # Use `docker build --build-arg REPO_SUFFIX=<CUSTOM_REPO_SUFFIX>` to override


### PR DESCRIPTION
There are now security vulnerabilities in Debian 9 that will not longer be patched