### PR TITLE
Switch from install-logging-agent.sh to add-logging-agent-repo.sh.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
         ca-certificates \
         adduser \
     # Install Logging Agent.
-    && curl -sS https://dl.google.com/cloudagents/install-logging-agent.sh | REPO_SUFFIX="$REPO_SUFFIX" REPO_CODENAME=stretch DO_NOT_INSTALL_CATCH_ALL_CONFIG=true bash \
+    && curl -sS https://dl.google.com/cloudagents/add-logging-agent-repo.sh | REPO_SUFFIX="$REPO_SUFFIX" REPO_CODENAME=stretch DO_NOT_INSTALL_CATCH_ALL_CONFIG=true bash /dev/stdin --also-install \
     # Store versions in the VERSION file.
     && dpkg -s google-fluentd | sed -nE 's/^Version: (.*)(-[^-]+)$/VERSION=\1\nGOOGLE_FLUENTD_VERSION=\1\2/p' >> /VERSION \
     && echo REPO_SUFFIX=$REPO_SUFFIX >> /VERSION \


### PR DESCRIPTION
This reverts #336 and reinstates #335.
This reverts commit fa66b74a578575a6130fecf91887ae8f9c97369c.

A new version of the `add-logging-agent-repo.sh` script was released
that supports `DO_NOT_INSTALL_CATCH_ALL_CONFIG`.