### PR TITLE
Revert Fluentd version from 1.12.3 to 1.11.2 for Windows as well.

### DIFF
--- a/config/software/fluentd.rb
+++ b/config/software/fluentd.rb
@@ -1,7 +1,10 @@
 name "fluentd"
 
-# Note: In order to update the Fluentd version, please update both here and also the fluentd version in
-# https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/fluent-plugin-google-cloud.gemspec.
+# Note: In order to update the Fluentd version, please update both here and also the fluentd versions in
+# https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/fluent-plugin-google-cloud.gemspec
+# and
+# https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/windows-installer/generate_sdl_agent_exe.ps1
+#
 # fluentd v1.11.2.
 default_version '3dde9396ee30263980ad2655fc78197b41d2b3fd'
 

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -147,7 +147,13 @@ $core_gems_rb = $SRC_ROOT + '\core_gems.rb'
 $plugin_gems_rb = $SRC_ROOT + '\plugin_gems.rb'
 # Pin ffi version until https://github.com/ffi/ffi/issues/868 is resolved.
 & $GEM_CMD install ffi:1.14.1 --no-document
-& $GEM_CMD install fluentd:1.12.3 --no-document
+
+# Note: In order to update the Fluentd version, please update both here and also
+# the fluentd versions in
+# https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/fluent-plugin-google-cloud.gemspec
+# and
+# https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/config/software/fluentd.rb
+& $GEM_CMD install fluentd:1.11.2 --no-document
 & $RUBY_EXE $gem_installer $core_gems_rb
 & $RUBY_EXE $gem_installer $plugin_gems_rb
 


### PR DESCRIPTION
Follow up of https://github.com/GoogleCloudPlatform/google-fluentd/pull/340