### PR TITLE
Download the RVM installation script and verify checksum before running.

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -31,7 +31,10 @@ RUN yum -y update \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+ && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+ && /bin/bash get-rvm-io.sh stable \
+ && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
  && yum -y clean all

--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -30,7 +30,7 @@ RUN yum -y update \
  && yum --enablerepo=rpmforge-extras -y upgrade git \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -19,7 +19,10 @@ RUN yum -y update \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+ && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+ && /bin/bash get-rvm-io.sh stable \
+ && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
  && yum -y clean all

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update \
         zlib-devel \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -19,7 +19,10 @@ RUN yum -y update \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+ && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+ && /bin/bash get-rvm-io.sh stable \
+ && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
  && yum -y clean all

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -18,7 +18,7 @@ RUN yum -y update \
         zlib-devel \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_debian/Dockerfile
+++ b/build/x86_64_debian/Dockerfile
@@ -18,7 +18,10 @@ RUN apt-get -y update \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+ && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+ && /bin/bash get-rvm-io.sh stable \
+ && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
  && apt-get -y clean

--- a/build/x86_64_debian/Dockerfile
+++ b/build/x86_64_debian/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get -y update \
         ruby \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -18,7 +18,10 @@ RUN zypper -n refresh \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+ && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+ && /bin/bash get-rvm-io.sh stable \
+ && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
  # Pretend we're on SLES 12.

--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -17,7 +17,7 @@ RUN zypper -n refresh \
         zlib-devel \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -17,7 +17,7 @@ RUN zypper -n refresh \
         zlib-devel \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
- && gpg2 --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
+ && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \

--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -18,7 +18,10 @@ RUN zypper -n refresh \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
- && (curl -sSL https://get.rvm.io | /bin/bash -s stable) \
+ && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
+ && (echo "fea24461e98d41528d6e28684aa4c216dbe903869bc3fcdb3493b6518fae2e7e get-rvm-io.sh" | sha256sum --check) \
+ && /bin/bash get-rvm-io.sh stable \
+ && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
  # Pretend we're on SLES 15.


### PR DESCRIPTION
This mitigates insecure behavior of piping a script from the internet directly into a shell.
b/192355502