### PR TITLE
Temporarily pin Nokogiri version to fix el6/el7/sles12 builds.

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -18,6 +18,9 @@ override :ruby, :version => '2.6.5'
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '3.0.0'
 override :postgresql, :version => '9.3.5'
+# TODO: Remove this override once there's a fix released for
+#       https://github.com/sparklemotion/nokogiri/issues/2302
+override :nokogiri, :version => '1.11.7'
 
 # td-agent dependencies/components
 dependency "td-agent"

--- a/config/software/td-agent.rb
+++ b/config/software/td-agent.rb
@@ -1,6 +1,10 @@
 name "td-agent"
 #version '' # git ref
 
+# TODO: Remove this override once there's a fix released for
+#       https://github.com/sparklemotion/nokogiri/issues/2302
+override :nokogiri, version: "1.11.7"
+
 dependency "jemalloc"
 dependency "ruby"
 dependency "nokogiri"

--- a/config/software/td-agent.rb
+++ b/config/software/td-agent.rb
@@ -1,10 +1,6 @@
 name "td-agent"
 #version '' # git ref
 
-# TODO: Remove this override once there's a fix released for
-#       https://github.com/sparklemotion/nokogiri/issues/2302
-override :nokogiri, version: "1.11.7"
-
 dependency "jemalloc"
 dependency "ruby"
 dependency "nokogiri"


### PR DESCRIPTION
http://b/195585297

Temporarily until https://github.com/sparklemotion/nokogiri/issues/2302 is fixed, to unblock nightly builds.

I was able to successfully build the agent with this change for each of the affected distros.