### PR TITLE
Revert "Temporarily pin Nokogiri version to fix el6/el7/sles12 builds."

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -18,9 +18,6 @@ override :ruby, :version => '2.6.5'
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '3.0.0'
 override :postgresql, :version => '9.3.5'
-# TODO: Remove this override once there's a fix released for
-#       https://github.com/sparklemotion/nokogiri/issues/2302
-override :nokogiri, :version => '1.11.7'
 
 # td-agent dependencies/components
 dependency "td-agent"


### PR DESCRIPTION
http://b/195756317

Reverts GoogleCloudPlatform/google-fluentd#350 since the fix for https://github.com/sparklemotion/nokogiri/issues/2302 was released in the latest [Nokogiri v1.12.3](https://github.com/sparklemotion/nokogiri/releases/tag/v1.12.3) (1.12.3 / 2021-08-06)

Tested on the 3 affected distros and all builds passed.