### PR TITLE
Upgrade omnibus-software to pick up chef/omnibus-software#1400.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/chef/omnibus-software.git
-  revision: 993d4e47d69217f4c9d62c5741e322160fb8a527
+  revision: bce0974a4f64bce2cc100a5baae26031ea430611
   specs:
     omnibus-software (4.0.0)
       omnibus (>= 5.6.1)


### PR DESCRIPTION
This updates `openssl` to `1.0.2y` and picks up fixes for [CVE-2021-23840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23840), [CVE-2020-1971](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1971), and [CVE-2020-1968](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-1968).