### PR TITLE
Force RVM to use the version of openssl that handles certificate chains.

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -41,5 +41,7 @@ RUN yum -y update \
  && /bin/bash get-rvm-io.sh stable \
  && rm -f get-rvm-io.sh \
  # RVM requires running in a login shell.
- && /bin/bash -l -c "rvm requirements && rvm install 2.5.3 && gem install bundler --no-document && gem update" \
+ # Force RVM to link in a newer openssl version.
+ && /bin/bash -l -c 'sed -i "/openssl_version/s/1.0.1i/1.0.1n/" $rvm_path/config/db && rvm pkg install openssl' \
+ && /bin/bash -l -c 'rvm requirements && rvm install 2.5.3 --with-openssl-dir=$rvm_path/usr && gem install bundler --no-document && gem update' \
  && yum -y clean all


### PR DESCRIPTION
…on CentOS 6. This should fix the build issues that remained after #364.

Detailed explanations at https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/ and https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/.
See https://www.mail-archive.com/openssl-users@openssl.org/msg90092.html for why version `1.0.1n` is used.