### PR TITLE
Actually bump the embedded Ruby version to 2.6.9.

### DIFF
--- a/config/patches/ruby/ruby-2.6.7_c99.patch
+++ b/config/patches/ruby/ruby-2.6.7_c99.patch
@@ -1,0 +1,12 @@
+--- ruby-2.6.7-orig/hash.c	2021-04-05 04:48:34.000000000 -0700
++++ ruby-2.6.7/hash.c	2021-04-16 13:50:06.000000000 -0700
+@@ -5658,7 +5658,8 @@
+     long keylen, elen;
+     const char *keyptr, *eptr;
+     RSTRING_GETMEM(key, keyptr, keylen);
+-    for (long i=0; i<RARRAY_LEN(keys); i++) {
++    long i;
++    for (i=0; i<RARRAY_LEN(keys); i++) {
+         VALUE e = RARRAY_AREF(keys, i);
+         RSTRING_GETMEM(e, eptr, elen);
+         if (elen != keylen) continue;

--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -14,7 +14,7 @@ build_iteration 1
 # creates required build directories
 dependency "preparation"
 
-override :ruby, :version => '2.6.5'
+override :ruby, :version => '2.6.9'
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '3.0.0'
 override :postgresql, :version => '9.3.5'

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -219,6 +219,9 @@ build do
   configure_command << "--with-ext=psych" if version.satisfies?("< 2.3")
   configure_command << "--with-bundled-md5" if fips_enabled
 
+  # resolve C99 code accidentally introduced in Ruby 2.6.7 and it's still in 2.6.8 :(
+  patch source: "ruby-2.6.7_c99.patch", plevel: 1, env: patch_env if version.satisfies?("~> 2.6.7")
+
   if aix?
     # need to patch ruby's configure file so it knows how to find shared libraries
     patch source: "ruby-aix-configure.patch", plevel: 1, env: patch_env


### PR DESCRIPTION
#371 was not enough.

Also cherry-pick a fix for Ruby build breakage.

b/216825879