### PR TITLE
Upgrade to grpc-1.43.1, to match the latest fluent-plugin-google-cloud.

### DIFF
--- a/core_gems.rb
+++ b/core_gems.rb
@@ -12,5 +12,5 @@ download "tzinfo-data", "1.2016.5"
 unless windows?
   # Gems that don't need to be fetched explicitly on Windows.
   fetch "google-protobuf", "3.15.8"
-  fetch "grpc", "1.20.0"
+  fetch "grpc", "1.43.1"
 end


### PR DESCRIPTION
Depends on #375 being merged and pushed through our build infrastructure.