### PR TITLE
Fix CentOS build Dockerfiles.

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -6,8 +6,7 @@ RUN sed -i \
         -e 's%^# *baseurl=http://mirror%baseurl=http://vault%' \
         /etc/yum.repos.d/CentOS-*.repo
 
-RUN yum -y update \
- && yum -y install \
+RUN yum -y install \
         # Needed for gpg2 and rvm installation.
         curl \
         # Needed for agent build.

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -1,7 +1,6 @@
 FROM centos:7
 
-RUN yum -y update \
- && yum -y install \
+RUN yum -y install \
         # Needed for gpg2 and rvm installation.
         curl \
         # Needed for agent build.

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -1,7 +1,12 @@
 FROM centos:8
 
-RUN yum -y update \
- && yum -y install \
+# CentOS 8 is EOL, so we have to switch to the vault repos.
+RUN sed -i \
+        -e 's%^mirrorlist%#mirrorlist%' \
+        -e 's%^# *baseurl=http://mirror%baseurl=http://vault%' \
+        /etc/yum.repos.d/CentOS-*.repo
+
+RUN yum -y install \
         # Needed for gpg2 and rvm installation.
         curl \
         # Needed for agent build.
@@ -14,6 +19,7 @@ RUN yum -y update \
         rpm-build \
         rpm-sign \
         ruby \
+        valgrind-devel \
         which \
         zlib-devel \
  # RVM GPG keys.


### PR DESCRIPTION
- Remove stray `yum update` commands
- Redirect CentOS 8 mirrors to the vault
- Add missing dependency on CentOS 8

See also Stackdriver/agent-packaging#128