### PR TITLE
Explicitly update ca-certificates in CentOS build Dockerfiles.

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -9,6 +9,7 @@ RUN sed -i \
 RUN yum -y install \
         # Needed for gpg2 and rvm installation.
         curl \
+        ca-certificates \
         # Needed for agent build.
         autoconf \
         bzip2 \

--- a/build/x86_64_centos7/Dockerfile
+++ b/build/x86_64_centos7/Dockerfile
@@ -3,6 +3,7 @@ FROM centos:7
 RUN yum -y install \
         # Needed for gpg2 and rvm installation.
         curl \
+        ca-certificates \
         # Needed for agent build.
         autoconf \
         bzip2 \

--- a/build/x86_64_centos8/Dockerfile
+++ b/build/x86_64_centos8/Dockerfile
@@ -9,6 +9,7 @@ RUN sed -i \
 RUN yum -y install \
         # Needed for gpg2 and rvm installation.
         curl \
+        ca-certificates \
         # Needed for agent build.
         autoconf \
         bzip2 \


### PR DESCRIPTION
This was needed after removing `yum update` (#377).