### PR TITLE
Override Openssl version to 1.1.1q and upgrade Postgres to 9.6.24

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -17,7 +17,7 @@ dependency "preparation"
 override :ruby, :version => '2.6.10'
 override :zlib, :version => '1.2.8'
 override :rubygems, :version => '3.0.0'
-override :postgresql, :version => '9.3.5'
+override :postgresql, :version => '9.6.24'
 
 # td-agent dependencies/components
 dependency "td-agent"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -1,3 +1,19 @@
+#
+# Copyright:: Copyright (c) Chef Software Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name "openssl"
 
 # Temporary overrides of the upstream openssl version from 1.0.2zb to 1.1.1q to pick up CVE fixes.

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -18,8 +18,10 @@ name "openssl"
 
 # Temporary overrides of the upstream openssl version from 1.0.2zb to 1.1.1q to pick up CVE fixes.
 # Background: https://github.com/chef/omnibus-software/pull/1682
-# The only difference between this file and the upstream at https://github.com/chef/omnibus-software/blob/a901ec26f8c704ba793c0609319f00f49e630d6b/config/software/openssl.rb is the "default_version".
+# The only difference between this file and the upstream at https://github.com/chef/omnibus-software/blob/a901ec26f8c704ba793c0609319f00f49e630d6b/config/software/openssl.rb
+# is the added openssl `1.1.1q` hash and the change of the "default_version".
 # The commit above is taken from https://github.com/GoogleCloudPlatform/google-fluentd/blob/57603141f950d1f3b919fe33f138c2c3e681a240/Gemfile.lock#L3 (with omnibus-software 4.0.0)
+#
 # TODO: remove this file after the we are able to upgrade to upstream ombibus-software version that comes with 1.1.1q+ version of openssl.
 overrides
 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -1,0 +1,165 @@
+name "openssl"
+
+# Temporary overrides of the upstream openssl version from 1.0.2zb to 1.1.1q to pick up CVE fixes.
+# Background: https://github.com/chef/omnibus-software/pull/1682
+# The only difference between this file and the upstream at https://github.com/chef/omnibus-software/blob/a901ec26f8c704ba793c0609319f00f49e630d6b/config/software/openssl.rb is the "default_version".
+# The commit above is taken from https://github.com/GoogleCloudPlatform/google-fluentd/blob/57603141f950d1f3b919fe33f138c2c3e681a240/Gemfile.lock#L3
+# TODO: remove this file after the upstream is able to move to 1.1.1q+ version of openssl.
+overrides
+
+license "OpenSSL"
+license_file "LICENSE"
+skip_transitive_dependency_licensing true
+
+dependency "cacerts"
+dependency "openssl-fips" if fips_mode?
+
+default_version "1.1.1q" # do_not_auto_update
+
+# Openssl builds engines as libraries into a special directory. We need to include
+# that directory in lib_dirs so omnibus can sign them during macOS deep signing.
+lib_dirs lib_dirs.concat(["#{install_dir}/embedded/lib/engines"])
+lib_dirs lib_dirs.concat(["#{install_dir}/embedded/lib/engines-1.1"]) if version.start_with?("1.1")
+
+# 1.0.2u was the last public release of 1.0.2. Subsequent releases come from a support contract with OpenSSL Software Services
+if version.satisfies?("< 1.1.0")
+  source url: "https://s3.amazonaws.com/chef-releng/openssl/openssl-#{version}.tar.gz", extract: :lax_tar
+else
+  # As of 2020-09-09 even openssl-1.0.0.tar.gz can be downloaded from /source/openssl-VERSION.tar.gz
+  # However, the latest releases are not in /source/old/VERSION/openssl-VERSION.tar.gz.
+  # Let's stick with the simpler one for now.
+  source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
+end
+
+version("1.1.1q") { source sha256: "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" }
+version("1.1.1l") { source sha256: "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" }
+
+version("1.0.2zb") { source sha256: "b7d8f8c895279caa651e7f3de9a7b87b8dd01a452ca3d9327f45a9ef31d0c518" }
+version("1.0.2za") { source sha256: "86ec5d2ecb53839e9ec999db7f8715d0eb7e534d8a1d8688ef25280fbeee2ff8" }
+
+relative_path "openssl-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  if aix?
+    env["M4"] = "/opt/freeware/bin/m4"
+  elsif mac_os_x? && arm?
+    env["CFLAGS"] << " -Qunused-arguments"
+  elsif freebsd?
+    # Should this just be in standard_compiler_flags?
+    env["LDFLAGS"] += " -Wl,-rpath,#{install_dir}/embedded/lib"
+  elsif windows?
+    # XXX: OpenSSL explicitly sets -march=i486 and expects that to be honored.
+    # It has OPENSSL_IA32_SSE2 controlling whether it emits optimized SSE2 code
+    # and the 32-bit calling convention involving XMM registers is...  vague.
+    # Do not enable SSE2 generally because the hand optimized assembly will
+    # overwrite registers that mingw expects to get preserved.
+    env["CFLAGS"] = "-I#{install_dir}/embedded/include"
+    env["CPPFLAGS"] = env["CFLAGS"]
+    env["CXXFLAGS"] = env["CFLAGS"]
+  end
+
+  configure_args = [
+    "--prefix=#{install_dir}/embedded",
+    "no-unit-test",
+    "no-comp",
+    "no-idea",
+    "no-mdc2",
+    "no-rc5",
+    "no-ssl2",
+    "no-ssl3",
+    "no-zlib",
+    "shared",
+  ]
+
+  # https://www.openssl.org/blog/blog/2021/09/13/LetsEncryptRootCertExpire/
+  configure_args += [ "-DOPENSSL_TRUSTED_FIRST_DEFAULT" ] if version.satisfies?(">= 1.0.2zb") && version.satisfies?("< 1.1.0")
+
+  configure_args += ["--with-fipsdir=#{install_dir}/embedded", "fips"] if fips_mode?
+
+  configure_cmd =
+    if aix?
+      "perl ./Configure aix64-cc"
+    elsif mac_os_x?
+      intel? ? "./Configure darwin64-x86_64-cc" : "./Configure darwin64-arm64-cc no-asm"
+    elsif smartos?
+      "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
+    elsif omnios?
+      "/bin/bash ./Configure solaris-x86-gcc"
+    elsif solaris2?
+      platform = sparc? ? "solaris64-sparcv9-gcc" : "solaris64-x86_64-gcc"
+      if version.satisfies?("< 1.1.0")
+        "/bin/bash ./Configure #{platform} -static-libgcc"
+      else
+        "./Configure #{platform} -static-libgcc"
+      end
+    elsif windows?
+      platform = windows_arch_i386? ? "mingw" : "mingw64"
+      "perl.exe ./Configure #{platform}"
+    else
+      prefix =
+        if linux? && ppc64?
+          "./Configure linux-ppc64"
+        elsif linux? && s390x?
+          # With gcc > 4.3 on s390x there is an error building
+          # with inline asm enabled
+          "./Configure linux64-s390x -DOPENSSL_NO_INLINE_ASM"
+        else
+          "./config"
+        end
+      "#{prefix} disable-gost"
+    end
+
+  patch_env = if aix?
+                # This enables omnibus to use 'makedepend'
+                # from fileset 'X11.adt.imake' (AIX install media)
+                env["PATH"] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+                penv = env.dup
+                penv["PATH"] = "/opt/freeware/bin:#{env["PATH"]}"
+                penv
+              else
+                env
+              end
+
+  if version.start_with? "1.0"
+    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
+  elsif version.start_with? "1.1"
+    patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
+  end
+
+  if version.start_with?("1.0.2") && mac_os_x? && arm?
+    patch source: "openssl-1.0.2x-darwin-arm64.patch"
+  end
+
+  if version.start_with?("1.0.2") && windows?
+    # Patch Makefile.org to update the compiler flags/options table for mingw.
+    patch source: "openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch", env: env
+  end
+
+  # Out of abundance of caution, we put the feature flags first and then
+  # the crazy platform specific compiler flags at the end.
+  configure_args << env["CFLAGS"] << env["LDFLAGS"]
+
+  configure_command = configure_args.unshift(configure_cmd).join(" ")
+
+  command configure_command, env: env, in_msys_bash: true
+
+  if version.start_with?("1.0.2") && windows?
+    patch source: "openssl-1.0.1j-windows-relocate-dll.patch", env: env
+  end
+
+  make "depend", env: env
+  # make -j N on openssl is not reliable
+  make env: env
+  if aix?
+    # We have to sudo this because you can't actually run slibclean without being root.
+    # Something in openssl changed in the build process so now it loads the libcrypto
+    # and libssl libraries into AIX's shared library space during the first part of the
+    # compile. This means we need to clear the space since it's not being used and we
+    # can't install the library that is already in use. Ideally we would patch openssl
+    # to make this not be an issue.
+    # Bug Ref: http://rt.openssl.org/Ticket/Display.html?id=2986&user=guest&pass=guest
+    command "sudo /usr/sbin/slibclean", env: env
+  end
+  make "install", env: env
+end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -19,8 +19,8 @@ name "openssl"
 # Temporary overrides of the upstream openssl version from 1.0.2zb to 1.1.1q to pick up CVE fixes.
 # Background: https://github.com/chef/omnibus-software/pull/1682
 # The only difference between this file and the upstream at https://github.com/chef/omnibus-software/blob/a901ec26f8c704ba793c0609319f00f49e630d6b/config/software/openssl.rb is the "default_version".
-# The commit above is taken from https://github.com/GoogleCloudPlatform/google-fluentd/blob/57603141f950d1f3b919fe33f138c2c3e681a240/Gemfile.lock#L3
-# TODO: remove this file after the upstream is able to move to 1.1.1q+ version of openssl.
+# The commit above is taken from https://github.com/GoogleCloudPlatform/google-fluentd/blob/57603141f950d1f3b919fe33f138c2c3e681a240/Gemfile.lock#L3 (with omnibus-software 4.0.0)
+# TODO: remove this file after the we are able to upgrade to upstream ombibus-software version that comes with 1.1.1q+ version of openssl.
 overrides
 
 license "OpenSSL"

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql"
-default_version "9.2.10"
+default_version "9.6.24"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -25,6 +25,10 @@ dependency "openssl"
 dependency "libedit"
 dependency "ncurses"
 dependency "config_guess"
+
+version "9.6.24" do
+  source md5: "132c726216a0e4b8540fcf974d25dc06"
+end
 
 version "9.2.14" do
   source md5: "ce2e50565983a14995f5dbcd3c35b627"


### PR DESCRIPTION
Fixes [b/238373633](http://b/238373633) (Update chef/omnibus-software version in google-fluentd to pick up newer OpenSSL version for CVE-2021-4160 and CVE-2022-0778). See the successful build in b/238373633#comment10

Upgrade openssl to pick up the following CVE fixes:
* https://nvd.nist.gov/vuln/detail/CVE-2021-4160: The issue only affects OpenSSL on MIPS platforms. Fixed in OpenSSL 3.0.1 (Affected 3.0.0). Fixed in OpenSSL 1.1.1m (Affected 1.1.1-1.1.1l). Fixed in OpenSSL 1.0.2zc
* https://nvd.nist.gov/vuln/detail/CVE-2022-0778: It was addressed in the releases of 1.1.1n and 3.0.2 on the 15th March 2022. Fixed in OpenSSL 3.0.2 (Affected 3.0.0,3.0.1). Fixed in OpenSSL 1.1.1n (Affected 1.1.1-1.1.1m). Fixed in OpenSSL 1.0.2zd (Affected 1.0.2-1.0.2zc).
* https://www.openssl.org/news/vulnerabilities-1.0.2.html

Also need to upgrade postgres because the openssl versions starting from 1.1.0 introduced a breaking change by deprecating SSL_library_init and a few other things. As a result, the original postgres version 9.2.10 [no longer builds](https://www.postgresql.org/message-id/20160627151604.GD1051@msg.df7cb.de).

Related issues:
* https://github.com/openssl/openssl/issues/6565
* https://postgrespro.com/list/thread-id/1895434
* https://github.com/tsiv/ccminer-cryptonight/issues/25