### PR TITLE
Manually update google-fluentd.rb version to 1.9.9

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -8,7 +8,7 @@ homepage "http://cloud.google.com/logging/docs/"
 description "Google Fluentd: A data collector for Google Cloud Logging"
 
 install_dir     "/opt/google-fluentd"
-build_version   "1.9.8"
+build_version   "1.9.9"
 build_iteration 1
 
 # creates required build directories


### PR DESCRIPTION
https://github.com/GoogleCloudPlatform/google-fluentd/pull/385#issuecomment-1208306100 didn't update agent version which caused release job failure due to duplicate package version being released