### PR TITLE
Fix centos6 Dockerfile build

### DIFF
--- a/build/x86_64_centos6/Dockerfile
+++ b/build/x86_64_centos6/Dockerfile
@@ -31,7 +31,7 @@ RUN yum -y install \
         -e 's%^# *baseurl=http://mirror%baseurl=http://vault%' \
         /etc/yum.repos.d/CentOS-*.repo \
  # CentOS 6 comes with git 1.7.1, and omnibus requires at least 1.7.2.
- && rpm -ivh http://ftp.tu-chemnitz.de/pub/linux/dag/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm \
+ && rpm -ivh http://rpmfind.net/linux/dag/redhat/el6/en/x86_64/dag/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm \
  && yum --enablerepo=rpmforge-extras -y upgrade git \
  # RVM GPG keys.
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \


### PR DESCRIPTION
Previous rpm is not available anymore, replacing the link with a live one.