### PR TITLE
Add valid SLES12 repo

### DIFF
--- a/build/x86_64_sles12/Dockerfile
+++ b/build/x86_64_sles12/Dockerfile
@@ -1,6 +1,8 @@
 FROM opensuse/leap:42.3
 
-RUN zypper -n refresh \
+RUN zypper modifyrepo -d 'OSS Update' \
+ && zypper ar http://opensuse.ucom.am/update/leap/42.3/oss/ 'OSS Update Mirror' \
+ && zypper -n refresh \
  && zypper -n install \
         # Needed for gpg2 and rvm installation.
         curl \


### PR DESCRIPTION
Build image generation is failing with:
Signature verification failed for file 'repomd.xml' from repository 'OSS Update'

Disabled that repo and added a new one from the list:
https://download.opensuse.org/distribution/leap/42.3/iso/openSUSE-Leap-42.3-DVD-x86_64.iso.mirrorlist