### PR TITLE
Update underlying debian docker image to 10-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.10-slim
+FROM debian:10-slim
 
 # Default google-fluentd to the latest stable.
 # Use `docker build --build-arg REPO_SUFFIX=<CUSTOM_REPO_SUFFIX>` to override


### PR DESCRIPTION
The old debian:10.10-slim was last updated a year ago, it had quite some cve problem inside. Thus updating it to use 10-slim