### PR TITLE
Support ARTIFACT_REGISTRY_REGION build arg in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,8 @@ FROM debian:10.10-slim
 # the version.
 ARG REPO_SUFFIX=20230327-2
 
+ARG ARTIFACT_REGISTRY_REGION=
+
 COPY entrypoint.sh Dockerfile /
 
 # TODO: This may be a moving target, figure out how to pin.
@@ -19,7 +21,7 @@ RUN apt-get update \
         ca-certificates \
         adduser \
     # Install Logging Agent.
-    && curl -sS https://dl.google.com/cloudagents/add-logging-agent-repo.sh | REPO_SUFFIX="$REPO_SUFFIX" REPO_CODENAME=stretch DO_NOT_INSTALL_CATCH_ALL_CONFIG=true bash /dev/stdin --also-install \
+    && curl -sS https://dl.google.com/cloudagents/add-logging-agent-repo.sh | REPO_SUFFIX="$REPO_SUFFIX" ARTIFACT_REGISTRY_REGION="$ARTIFACT_REGISTRY_REGION" REPO_CODENAME=stretch DO_NOT_INSTALL_CATCH_ALL_CONFIG=true bash /dev/stdin --also-install \
     # Store versions in the VERSION file.
     && dpkg -s google-fluentd | sed -nE 's/^Version: (.*)(-[^-]+)$/VERSION=\1\nGOOGLE_FLUENTD_VERSION=\1\2/p' >> /VERSION \
     && echo REPO_SUFFIX=$REPO_SUFFIX >> /VERSION \


### PR DESCRIPTION
This is one change necessary to get ARTIFACT_REGISTRY_REGION forwarded from our release automation tool all the way to the install script. I also need to change a file inside git-on-borg and some release automation files too.