### PR TITLE
Compile Ruby with jemalloc to optimize memory usage.

### DIFF
--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -2,8 +2,13 @@ name "jemalloc"
 default_version "4.5.0"
 
 # for td-agent
-version("2.2.5") do
-  md5 = 'a5c4332705ed0e3fff1ac73cfe975640'
+version("4.5.0") do
+  sha512 = '76953363fe1007952232220afa1a91da4c1c33c02369b5ad239d8dd1d0792141197c15e8489a8f4cd301b08494e65cadd8ecd34d025cb0285700dd78d7248821'
+  source :sha512 => sha512,
+         :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/sha512/#{sha512}/jemalloc-#{version}.tar.bz2"
+end
+version("4.2.1") do
+  md5 = '094b0a7b8c77c464d0dc8f0643fd3901'
   source :md5 => md5,
          :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
@@ -12,15 +17,10 @@ version("3.6.0") do
   source :md5 => md5,
          :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
 end
-version("4.2.1") do
-  md5 = '094b0a7b8c77c464d0dc8f0643fd3901'
+version("2.2.5") do
+  md5 = 'a5c4332705ed0e3fff1ac73cfe975640'
   source :md5 => md5,
          :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/#{md5}/jemalloc-#{version}.tar.bz2"
-end
-version("4.5.0") do
-  sha512 = '76953363fe1007952232220afa1a91da4c1c33c02369b5ad239d8dd1d0792141197c15e8489a8f4cd301b08494e65cadd8ecd34d025cb0285700dd78d7248821'
-  source :sha512 => sha512,
-         :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/sha512/#{sha512}/jemalloc-#{version}.tar.bz2"
 end
 
 # On Mac, this file blocks package building at health check so add to whitelist

--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -1,7 +1,12 @@
 name "jemalloc"
-default_version "4.5.0"
+default_version "5.3.0"
 
 # for td-agent
+version("5.3.0") do
+  sha512 = '22907bb052096e2caffb6e4e23548aecc5cc9283dce476896a2b1127eee64170e3562fa2e7db9571298814a7a2c7df6e8d1fbe152bd3f3b0c1abec22a2de34b1'
+  source :sha512 => sha512,
+         :url => "http://src.fedoraproject.org/repo/pkgs/jemalloc/jemalloc-#{version}.tar.bz2/sha512/#{sha512}/jemalloc-#{version}.tar.bz2"
+end
 version("4.5.0") do
   sha512 = '76953363fe1007952232220afa1a91da4c1c33c02369b5ad239d8dd1d0792141197c15e8489a8f4cd301b08494e65cadd8ecd34d025cb0285700dd78d7248821'
   source :sha512 => sha512,

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -48,6 +48,7 @@ dependency "libyaml"
 # Ignore on windows - TDM GCC comes with libiconv in the runtime
 # and that's the only one we will ever use.
 dependency "libiconv"
+dependency "jemalloc"
 
 # The SHA256 checksums below are for the *.tar.gz packages from https://www.ruby-lang.org/en/downloads/releases.
 version("3.1.3")      { source sha256: "5ea498a35f4cd15875200a52dde42b6eb179e1264e17d78732c3a57cd1c6ab9e" }
@@ -227,6 +228,7 @@ build do
 
   configure_command = ["--with-out-ext=dbm,gdbm,probe,racc,sdbm,tk",
                        "--enable-shared",
+                       "--with-jemalloc",
                        "--enable-libedit",
                        "--disable-install-doc",
                        "--without-gmp",


### PR DESCRIPTION
The agent uses significantly more memory with Ruby 3 than with Ruby 2 — this is an attempt to alleviate that.

[b/254273286](http://b/254273286).