### PR TITLE
Update build container to Debian 10

### DIFF
--- a/build/x86_64_debian/Dockerfile
+++ b/build/x86_64_debian/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update \
  && mkdir -p ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
  && gpg2 --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
  # Workaround for https://stackoverflow.com/q/64653051.
- && sudo ln -s /bin/mkdir /usr/bin/mkdir
+ && ln -s /bin/mkdir /usr/bin/mkdir \
  # Install RVM.
  && curl -sSL -o get-rvm-io.sh https://get.rvm.io \
  && (echo "7bbf79be95e516f72945e558a4290b40ff8714158140a00991d42172ff78e209  get-rvm-io.sh" | sha256sum --check) \


### PR DESCRIPTION
Debian 9 is deprecated, and that's causing me various issues elsewhere.

[b/241276506](http://b/241276506)

I tested out this change by:

1. building the docker image in cloud build using a custom trigger on this PR
2. building google-fluentd in the resulting image in the changelist with description "Try new debian-10 build container." Success: http://sponge2/5b2a865f-23a0-4810-9377-27ff4ebe2271

I have not tried running integration tests against the resulting google-fluentd, but I figure the ordinary release process (nightlies) will do that.