### PR TITLE
fluentd: update fluentd version to v1.16.2

### DIFF
--- a/config/software/fluentd.rb
+++ b/config/software/fluentd.rb
@@ -5,8 +5,8 @@ name "fluentd"
 # and
 # https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/windows-installer/generate_sdl_agent_exe.ps1
 #
-# fluentd v1.13.3.
-default_version '12de3b5a260a174fe4a419036d6e2b2e18fe7497'
+# fluentd v1.16.2.
+default_version 'd5685ada81ac89a35a79965f1e94bbe5952a5d3a'
 
 dependency "ruby"
 #dependency "bundler"

--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -174,7 +174,7 @@ $plugin_gems_rb = $SRC_ROOT + '\plugin_gems.rb'
 # https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/fluent-plugin-google-cloud.gemspec
 # and
 # https://github.com/GoogleCloudPlatform/google-fluentd/blob/master/config/software/fluentd.rb
-& $GEM_CMD install fluentd:1.13.3 --no-document
+& $GEM_CMD install fluentd:1.16.2 --no-document
 & $RUBY_EXE $gem_installer $core_gems_rb
 & $RUBY_EXE $gem_installer $plugin_gems_rb
 


### PR DESCRIPTION
Tracker: [b/293350172](http://b/293350172)

There have been several memory leak fixes since v1.13.3. Updating the version and having this run using our soak tests will help us see if we see some improvements. 

Related PR: https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/510