### PR TITLE
Pin unf_ext to 0.0.8.2 to avoid compilation errors.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ gem 'open_uri_redirections', '0.2.1'
 gem 'test-kitchen',    '~> 2.4'
 gem 'kitchen-vagrant', '~> 1.6'
 
+# b/310663890: Temporarily pin unf_ext to avoid compilation errors.
+gem 'unf_ext', '0.0.8.2'
+
 group :test do
   gem 'rake', '~> 13.0.6'
   gem 'serverspec', '~> 2.18.0'

--- a/plugin_gems.rb
+++ b/plugin_gems.rb
@@ -26,6 +26,8 @@ download "fluent-plugin-prometheus", "1.4.0"
 download "fluent-plugin-multi-format-parser", "1.0.0"
 download "fluent-plugin-record-reformer", "0.9.1"
 download "fluent-plugin-record-modifier", "2.0.1"
+# b/310663890: Temporarily pin unf_ext to avoid compilation errors.
+download "unf_ext", "0.0.8.2"
 download "fluent-plugin-kubernetes_metadata_filter", "2.5.2"
 download "systemd-journal", "1.4.2"
 download "fluent-plugin-systemd", "1.0.5"


### PR DESCRIPTION
[b/310663890](http://b/310663890)

Works around https://github.com/knu/ruby-unf_ext/issues/74.