### PR TITLE
Fix Ruby installation on Windows

### DIFF
--- a/windows-installer/generate_sdl_agent_exe.ps1
+++ b/windows-installer/generate_sdl_agent_exe.ps1
@@ -139,7 +139,7 @@ Set-PSDebug -Trace 1
 ##############################
 
 # Install ruby to the main install location and wait for it to finish.
-& $RUBY_INSTALLER /verysilent /tasks="assocfiles,modpath" /dir=$SD_LOGGING_AGENT_DIR | Out-Null
+& $RUBY_INSTALLER /verysilent /tasks="assocfiles,modpath" /dir=$SD_LOGGING_AGENT_DIR /currentuser | Out-Null
 
 # Remove the ruby uninstallers and the installer.
 rm $SD_LOGGING_AGENT_DIR\unins*


### PR DESCRIPTION
Version 3.3.5 of the installer now requires `/currentuser` or `/allusers` to avoid spawning an unclickable dialog.

Alluded to in https://github.com/oneclick/rubyinstaller2/commit/595b8882f0a0d9d8ba7ed746fe6efe849f7b6700