### PR TITLE
Revert systemd-sysvcompat depedendency

### DIFF
--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -53,12 +53,10 @@ when "linux"
     runtime_dependency "insserv-compat"
     # sysvinit-tools is required for insserv-compat, but isn't a dependency
     runtime_dependency "sysvinit-tools"
-    if /^15/ =~ ohai["platform_version"]
-      # systemd-sysvcompat is required for providing
-      # /usr/lib/systemd/systemd-sysv-install, which is needed for init.d and
-      # is missing from SLES 15.6 onwards (b/372000696)
-      runtime_dependency "systemd-sysvcompat"
-    end
+    # systemd-sysvcompat is required for providing
+    # /usr/lib/systemd/systemd-sysv-install, which is needed for init.d and
+    # is missing from SLES 15.6 onwards (b/372000696)
+    runtime_dependency "systemd-sysvcompat"
   end
 end
 

--- a/config/projects/google-fluentd.rb
+++ b/config/projects/google-fluentd.rb
@@ -53,10 +53,6 @@ when "linux"
     runtime_dependency "insserv-compat"
     # sysvinit-tools is required for insserv-compat, but isn't a dependency
     runtime_dependency "sysvinit-tools"
-    # systemd-sysvcompat is required for providing
-    # /usr/lib/systemd/systemd-sysv-install, which is needed for init.d and
-    # is missing from SLES 15.6 onwards (b/372000696)
-    runtime_dependency "systemd-sysvcompat"
   end
 end
 


### PR DESCRIPTION
Unfortunately this is causing too many compatibility problems on existing supported variants of SLES 15. For now, `systemd-sysvcompat` needs to be installed manually if running on an SP6-based variant.

[b/372000696](http://b/372000696)