### PR TITLE
Upgrade SLES 15 builder image

### DIFF
--- a/build/x86_64_sles15/Dockerfile
+++ b/build/x86_64_sles15/Dockerfile
@@ -1,9 +1,11 @@
-FROM opensuse/leap:15.1
+FROM opensuse/leap:15.5
 
 RUN zypper -n refresh \
  && zypper -n install \
         # Needed for gpg2 and rvm installation.
         curl \
+        dirmngr \
+        procps \
         # Needed for agent build.
         autoconf \
         bzip2 \
@@ -27,5 +29,5 @@ RUN zypper -n refresh \
  # RVM requires running in a login shell.
  && /bin/bash -l -c "rvm requirements && rvm install 3.3.6 && gem install bundler --no-document && gem update --no-document" \
  # Pretend we're on SLES 15.
- && /bin/sed -i -e 's/VERSION="15.1"/VERSION="15-SP1"/' /etc/os-release \
+ && /bin/sed -i -e 's/VERSION="15.5"/VERSION="15-SP5"/' /etc/os-release \
  && zypper -n clean


### PR DESCRIPTION
SP1 is EOL and now ships a version of glibc that's too old to build google-fluentd (2.26 < 2.27). SP5 has a much newer version. Would like to avoid SP6 for now due to the amount of breaking changes it introduces.

Tested by successfully building the builder image locally and then using that to successfully build a package locally.

http://b/388874195