### PR TITLE
Update the xz package to download from GitHub

### DIFF
--- a/config/software/xz.rb
+++ b/config/software/xz.rb
@@ -1,5 +1,9 @@
 name "xz"
-default_version "5.2.3"
+default_version "5.8.1"
+
+version "5.8.1" do
+  source md5: "209cb25608ab0841f68df4d50d0faa22"
+end
 
 version "5.2.3" do
   source md5: "ef68674fb47a8b8e741b34e429d86e9d"

--- a/config/software/xz.rb
+++ b/config/software/xz.rb
@@ -13,7 +13,8 @@ version "5.2.1" do
   source md5: "3e44c766c3fb4f19e348e646fcd5778a"
 end
 
-source url: "https://storage.googleapis.com/stackdriver-fluentd-vendor-storage/xz-#{version}.tar.gz"
+# Example: https://github.com/tukaani-project/xz/releases/download/v5.8.1/xz-5.8.1.tar.gz
+source url: "https://github.com/tukaani-project/xz/releases/download/v#{version}/xz-#{version}.tar.gz"
 
 relative_path "xz-#{version}"
 


### PR DESCRIPTION
[b/432705657](http://b/432705657)

Test passed: https://fusion2.corp.google.com/ci;prev=s/kokoro/prod:stackdriver_agents%2Flogging%2Fx86_64_linux%2Frelease/activity/86c69adc-339b-46e6-9096-31dfc18303c2/log