### PR TITLE
Update Dockerfile to use debian:bookworm-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10.13-slim
+FROM debian:bookworm-slim
 
 # Default google-fluentd to the latest stable.
 # Use `docker build --build-arg REPO_SUFFIX=<CUSTOM_REPO_SUFFIX>` to override


### PR DESCRIPTION
Debian 10 was EOL so we were running into issues with the repository.